### PR TITLE
feat: add pages for creating and searching annonces

### DIFF
--- a/src/pages/CreerAnnonce.tsx
+++ b/src/pages/CreerAnnonce.tsx
@@ -1,0 +1,80 @@
+import React, { useState } from 'react';
+import { supabase } from '../lib/supabase';
+
+const CreerAnnonce = () => {
+  const [formData, setFormData] = useState({
+    titre: '',
+    description: '',
+    ville: '',
+    prix: ''
+  });
+  const [status, setStatus] = useState<string | null>(null);
+
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
+    setFormData({ ...formData, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const { error } = await supabase
+      .from('annonces')
+      .insert([{ ...formData, prix: parseFloat(formData.prix) }]);
+
+    if (error) {
+      setStatus(`Erreur : ${error.message}`);
+    } else {
+      setStatus('Annonce créée avec succès');
+      setFormData({ titre: '', description: '', ville: '', prix: '' });
+    }
+  };
+
+  return (
+    <div className="max-w-md mx-auto">
+      <h1 className="text-2xl font-bold mb-4">Créer une annonce</h1>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <input
+          type="text"
+          name="titre"
+          value={formData.titre}
+          onChange={handleChange}
+          placeholder="Titre"
+          className="w-full border rounded p-2"
+        />
+        <textarea
+          name="description"
+          value={formData.description}
+          onChange={handleChange}
+          placeholder="Description"
+          className="w-full border rounded p-2"
+        />
+        <input
+          type="text"
+          name="ville"
+          value={formData.ville}
+          onChange={handleChange}
+          placeholder="Ville"
+          className="w-full border rounded p-2"
+        />
+        <input
+          type="number"
+          name="prix"
+          value={formData.prix}
+          onChange={handleChange}
+          placeholder="Prix"
+          className="w-full border rounded p-2"
+        />
+        <button
+          type="submit"
+          className="bg-blue-600 text-white px-4 py-2 rounded"
+        >
+          Créer
+        </button>
+      </form>
+      {status && <p className="mt-4">{status}</p>}
+    </div>
+  );
+};
+
+export default CreerAnnonce;

--- a/src/pages/RechercheAnnonces.tsx
+++ b/src/pages/RechercheAnnonces.tsx
@@ -1,0 +1,59 @@
+import React, { useState } from 'react';
+import { supabase } from '../lib/supabase';
+
+type Annonce = {
+  id: number;
+  titre: string;
+  description: string;
+  ville: string;
+  prix: number;
+};
+
+const RechercheAnnonces = () => {
+  const [ville, setVille] = useState('');
+  const [annonces, setAnnonces] = useState<Annonce[]>([]);
+
+  const rechercher = async () => {
+    const { data, error } = await supabase
+      .from('annonces')
+      .select('*')
+      .eq('ville', ville);
+
+    if (!error && data) {
+      setAnnonces(data as Annonce[]);
+    }
+  };
+
+  return (
+    <div className="max-w-md mx-auto">
+      <h1 className="text-2xl font-bold mb-4">Rechercher des annonces</h1>
+      <div className="space-y-4">
+        <input
+          type="text"
+          value={ville}
+          onChange={(e) => setVille(e.target.value)}
+          placeholder="Ville"
+          className="w-full border rounded p-2"
+        />
+        <button
+          onClick={rechercher}
+          className="bg-blue-600 text-white px-4 py-2 rounded"
+        >
+          Rechercher
+        </button>
+      </div>
+      <ul className="mt-4 space-y-2">
+        {annonces.map((annonce) => (
+          <li key={annonce.id} className="border p-2 rounded">
+            <h2 className="font-semibold">
+              {annonce.titre} - {annonce.prix}€
+            </h2>
+            <p>{annonce.description}</p>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default RechercheAnnonces;


### PR DESCRIPTION
## Summary
- create CreerAnnonce page with form to insert new annonces using Supabase
- add RechercheAnnonces page to query annonces by city

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: `Unexpected any` and `no-unused-vars` in existing files)


------
https://chatgpt.com/codex/tasks/task_e_689710fd0c1c8327998165fe5c416537