### PR TITLE
feat: add authentication pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,9 @@
 import { Routes, Route, useLocation } from "react-router-dom";
 import { useEffect } from "react";
+import { Toaster } from "react-hot-toast";
 import LandingPage from "./pages/LandingPage";
+import LoginPage from "./pages/LoginPage";
+import SignupPage from "./pages/SignupPage";
 
 function ScrollToHash() {
   const { hash } = useLocation();
@@ -10,17 +13,15 @@ function ScrollToHash() {
   return null;
 }
 
-const Login = () => <div className="sg-section sg-container">Login</div>;
-const Signup = () => <div className="sg-section sg-container">Signup</div>;
-
 export default function App() {
   return (
     <>
       <ScrollToHash />
+      <Toaster position="top-right" />
       <Routes>
         <Route path="/" element={<LandingPage />} />
-        <Route path="/login" element={<Login />} />
-        <Route path="/signup" element={<Signup />} />
+        <Route path="/login" element={<LoginPage />} />
+        <Route path="/signup" element={<SignupPage />} />
       </Routes>
     </>
   );

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,0 +1,60 @@
+import { useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { supabase } from "../supabase";
+import { toast } from "react-hot-toast";
+
+export default function LoginPage() {
+  const navigate = useNavigate();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    const { error } = await supabase.auth.signInWithPassword({ email, password });
+    setLoading(false);
+    if (error) {
+      toast.error(error.message);
+    } else {
+      toast.success("Connexion réussie");
+      navigate("/");
+    }
+  };
+
+  return (
+    <section className="sg-section">
+      <div className="sg-container sg-max-w-md">
+        <h2 className="sg-title-h2 sg-mb-6">Se connecter</h2>
+        <form onSubmit={handleSubmit} className="sg-flex sg-flex-col sg-gap-4">
+          <input
+            type="email"
+            required
+            placeholder="Email"
+            className="sg-w-full sg-rounded-lg sg-border sg-border-black/20 sg-px-4 sg-py-2"
+            value={email}
+            onChange={e => setEmail(e.target.value)}
+          />
+          <input
+            type="password"
+            required
+            placeholder="Mot de passe"
+            className="sg-w-full sg-rounded-lg sg-border sg-border-black/20 sg-px-4 sg-py-2"
+            value={password}
+            onChange={e => setPassword(e.target.value)}
+          />
+          <button
+            type="submit"
+            className="sg-btn-primary"
+            disabled={loading}
+          >
+            {loading ? "Connexion..." : "Se connecter"}
+          </button>
+        </form>
+        <p className="sg-mt-4 sg-text-center">
+          Pas de compte ? <Link to="/signup" className="sg-text-primary">Créer un compte</Link>
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -1,0 +1,66 @@
+import { useState } from "react";
+import { Link, useNavigate, useSearchParams } from "react-router-dom";
+import { supabase } from "../supabase";
+import { toast } from "react-hot-toast";
+
+export default function SignupPage() {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const role = searchParams.get("role") || "";
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    const { error } = await supabase.auth.signUp({
+      email,
+      password,
+      options: { data: { role } },
+    });
+    setLoading(false);
+    if (error) {
+      toast.error(error.message);
+    } else {
+      toast.success("Vérifiez vos emails pour confirmer");
+      navigate("/login");
+    }
+  };
+
+  return (
+    <section className="sg-section">
+      <div className="sg-container sg-max-w-md">
+        <h2 className="sg-title-h2 sg-mb-6">Créer un compte</h2>
+        <form onSubmit={handleSubmit} className="sg-flex sg-flex-col sg-gap-4">
+          <input
+            type="email"
+            required
+            placeholder="Email"
+            className="sg-w-full sg-rounded-lg sg-border sg-border-black/20 sg-px-4 sg-py-2"
+            value={email}
+            onChange={e => setEmail(e.target.value)}
+          />
+          <input
+            type="password"
+            required
+            placeholder="Mot de passe"
+            className="sg-w-full sg-rounded-lg sg-border sg-border-black/20 sg-px-4 sg-py-2"
+            value={password}
+            onChange={e => setPassword(e.target.value)}
+          />
+          <button
+            type="submit"
+            className="sg-btn-primary"
+            disabled={loading}
+          >
+            {loading ? "Création..." : "Créer un compte"}
+          </button>
+        </form>
+        <p className="sg-mt-4 sg-text-center">
+          Déjà inscrit ? <Link to="/login" className="sg-text-primary">Se connecter</Link>
+        </p>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add login page for email/password auth via Supabase
- add signup page storing role metadata
- integrate toaster and routes

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689e4ea038d483279e313c9ba323b2d6