### PR TITLE
feat: add basic dashboard and annonces

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,10 @@ import { Toaster } from "react-hot-toast";
 import LandingPage from "./pages/LandingPage";
 import LoginPage from "./pages/LoginPage";
 import SignupPage from "./pages/SignupPage";
+import DashboardPage from "./pages/DashboardPage";
+import AnnoncesPage from "./pages/AnnoncesPage";
+import NewAnnoncePage from "./pages/NewAnnoncePage";
+import ProtectedRoute from "./components/ProtectedRoute";
 
 function ScrollToHash() {
   const { hash } = useLocation();
@@ -22,6 +26,11 @@ export default function App() {
         <Route path="/" element={<LandingPage />} />
         <Route path="/login" element={<LoginPage />} />
         <Route path="/signup" element={<SignupPage />} />
+        <Route element={<ProtectedRoute />}>
+          <Route path="/dashboard" element={<DashboardPage />} />
+          <Route path="/annonces" element={<AnnoncesPage />} />
+          <Route path="/annonces/new" element={<NewAnnoncePage />} />
+        </Route>
       </Routes>
     </>
   );

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,9 +1,17 @@
 import { useState } from "react";
 import { Link, NavLink } from "react-router-dom";
+import { useAuth } from "../contexts/AuthContext";
+import { supabase } from "../supabase";
 
 export default function Navbar() {
   const [open, setOpen] = useState(false);
+  const { user } = useAuth();
   const item = "sg-px-3 sg-py-2 sg-rounded-lg sg-text-black/85 hover:sg-text-black hover:sg-bg-black/5 sg-transition";
+
+  const handleLogout = async () => {
+    await supabase.auth.signOut();
+    setOpen(false);
+  };
 
   return (
     <header className="sg-sticky sg-top-0 sg-z-50 sg-border-b sg-border-black/10 sg-bg-base/70 sg-backdrop-blur">
@@ -13,8 +21,18 @@ export default function Navbar() {
         <nav className="sg-hidden md:sg-flex sg-items-center sg-gap-1">
           <a href="#features" className={item}>Fonctionnalités</a>
           <a href="#how" className={item}>Comment ça marche</a>
-          <NavLink to="/login" className={item}>Se connecter</NavLink>
-          <NavLink to="/signup" className="sg-btn-primary sg-ml-1">Créer un compte</NavLink>
+          {user ? (
+            <>
+              <NavLink to="/annonces" className={item}>Annonces</NavLink>
+              <NavLink to="/dashboard" className={item}>Dashboard</NavLink>
+              <button onClick={handleLogout} className={item}>Se déconnecter</button>
+            </>
+          ) : (
+            <>
+              <NavLink to="/login" className={item}>Se connecter</NavLink>
+              <NavLink to="/signup" className="sg-btn-primary sg-ml-1">Créer un compte</NavLink>
+            </>
+          )}
         </nav>
 
         <button
@@ -30,8 +48,18 @@ export default function Navbar() {
           <div className="sg-container sg-py-3 sg-flex sg-flex-col">
             <a href="#features" onClick={() => setOpen(false)} className="sg-py-2">Fonctionnalités</a>
             <a href="#how" onClick={() => setOpen(false)} className="sg-py-2">Comment ça marche</a>
-            <Link to="/login" onClick={() => setOpen(false)} className="sg-py-2">Se connecter</Link>
-            <Link to="/signup" onClick={() => setOpen(false)} className="sg-btn-primary sg-mt-2 sg-w-full sg-text-center">Créer un compte</Link>
+            {user ? (
+              <>
+                <Link to="/annonces" onClick={() => setOpen(false)} className="sg-py-2">Annonces</Link>
+                <Link to="/dashboard" onClick={() => setOpen(false)} className="sg-py-2">Dashboard</Link>
+                <button onClick={handleLogout} className="sg-py-2 sg-text-left">Se déconnecter</button>
+              </>
+            ) : (
+              <>
+                <Link to="/login" onClick={() => setOpen(false)} className="sg-py-2">Se connecter</Link>
+                <Link to="/signup" onClick={() => setOpen(false)} className="sg-btn-primary sg-mt-2 sg-w-full sg-text-center">Créer un compte</Link>
+              </>
+            )}
           </div>
         </div>
       )}

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -1,0 +1,8 @@
+import { Navigate, Outlet } from "react-router-dom";
+import { useAuth } from "../contexts/AuthContext";
+
+export default function ProtectedRoute() {
+  const { user, loading } = useAuth();
+  if (loading) return <div className="sg-container sg-py-10">Chargement...</div>;
+  return user ? <Outlet /> : <Navigate to="/login" replace />;
+}

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,0 +1,39 @@
+import { createContext, useContext, useEffect, useState } from "react";
+import type { User } from "@supabase/supabase-js";
+import { supabase } from "../supabase";
+
+interface AuthContextValue {
+  user: User | null;
+  loading: boolean;
+}
+
+const AuthContext = createContext<AuthContextValue>({ user: null, loading: true });
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [user, setUser] = useState<User | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, session) => {
+      setUser(session?.user ?? null);
+      setLoading(false);
+    });
+
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      setUser(session?.user ?? null);
+      setLoading(false);
+    });
+
+    return () => subscription.unsubscribe();
+  }, []);
+
+  return (
+    <AuthContext.Provider value={{ user, loading }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export const useAuth = () => useContext(AuthContext);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,11 +3,14 @@ import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 import './index.css';
+import { AuthProvider } from './contexts/AuthContext';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
     <BrowserRouter>
-      <App />
+      <AuthProvider>
+        <App />
+      </AuthProvider>
     </BrowserRouter>
-  </React.StrictMode>
+  </React.StrictMode>,
 );

--- a/src/pages/AnnoncesPage.tsx
+++ b/src/pages/AnnoncesPage.tsx
@@ -1,0 +1,43 @@
+import { useEffect, useState } from "react";
+import { supabase } from "../supabase";
+import { Link } from "react-router-dom";
+
+interface Annonce {
+  id: string;
+  titre: string;
+  description: string;
+}
+
+export default function AnnoncesPage() {
+  const [annonces, setAnnonces] = useState<Annonce[]>([]);
+
+  useEffect(() => {
+    supabase
+      .from("annonces")
+      .select("id, titre, description")
+      .then(({ data }) => {
+        if (data) setAnnonces(data);
+      });
+  }, []);
+
+  return (
+    <section className="sg-section">
+      <div className="sg-container">
+        <div className="sg-flex sg-items-center sg-justify-between">
+          <h2 className="sg-title-h2">Annonces</h2>
+          <Link to="/annonces/new" className="sg-btn-primary">
+            Nouvelle annonce
+          </Link>
+        </div>
+        <ul className="sg-mt-6 sg-grid sg-gap-4">
+          {annonces.map(a => (
+            <li key={a.id} className="sg-card">
+              <h3 className="sg-font-semibold">{a.titre}</h3>
+              <p className="sg-text-black/80 sg-mt-2">{a.description}</p>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  );
+}

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -1,0 +1,32 @@
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { supabase } from "../supabase";
+import { useAuth } from "../contexts/AuthContext";
+
+export default function DashboardPage() {
+  const { user } = useAuth();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!user) navigate("/login");
+  }, [user, navigate]);
+
+  const handleLogout = async () => {
+    await supabase.auth.signOut();
+    navigate("/");
+  };
+
+  return (
+    <section className="sg-section">
+      <div className="sg-container">
+        <h2 className="sg-title-h2">Tableau de bord</h2>
+        <p className="sg-mt-4">Bienvenue {user?.email}</p>
+        <div className="sg-mt-6">
+          <button onClick={handleLogout} className="sg-btn-primary">
+            Se déconnecter
+          </button>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/pages/NewAnnoncePage.tsx
+++ b/src/pages/NewAnnoncePage.tsx
@@ -1,0 +1,42 @@
+import { useState } from "react";
+import { supabase } from "../supabase";
+import { useNavigate } from "react-router-dom";
+
+export default function NewAnnoncePage() {
+  const [titre, setTitre] = useState("");
+  const [description, setDescription] = useState("");
+  const navigate = useNavigate();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const { error } = await supabase.from("annonces").insert({ titre, description });
+    if (!error) navigate("/annonces");
+  };
+
+  return (
+    <section className="sg-section">
+      <div className="sg-container sg-max-w-md">
+        <h2 className="sg-title-h2 sg-mb-6">Nouvelle annonce</h2>
+        <form onSubmit={handleSubmit} className="sg-flex sg-flex-col sg-gap-4">
+          <input
+            className="sg-w-full sg-rounded-lg sg-border sg-border-black/20 sg-px-4 sg-py-2"
+            value={titre}
+            onChange={e => setTitre(e.target.value)}
+            placeholder="Titre"
+            required
+          />
+          <textarea
+            className="sg-w-full sg-rounded-lg sg-border sg-border-black/20 sg-px-4 sg-py-2"
+            value={description}
+            onChange={e => setDescription(e.target.value)}
+            placeholder="Description"
+            required
+          />
+          <button type="submit" className="sg-btn-primary">
+            Publier
+          </button>
+        </form>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add authentication context to share user session across app
- introduce protected routes, dashboard, and annonces pages with creation form
- update navbar and routing to support logged-in navigation

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689e6973f0c88327aff683801373bca8