### PR TITLE
Add seat booking, messaging, and contract features

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sharings
 
-Marketplace reliant salons de coiffure/esthétique et indépendants.
+Marketplace reliant salons de coiffure/esthétique et indépendants avec réservation de sièges, messagerie et création de contrat.
 
 ## Installation
 
@@ -75,6 +75,9 @@ Configurer l'onglet **Auth** avec les URL de redirection `http://localhost:5173`
 - `/login` / `/register`
 - `/creer-annonce` réservé aux salons
 - `/recherche` réservé aux indépendants
+- `/reservations` : planning de réservation de siège
+- `/messages` : messagerie simple
+- `/contrat` : génération de contrat
 
 ## Types
 - `salon` : peut créer des annonces

--- a/index.html
+++ b/index.html
@@ -3,8 +3,8 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Sharings — Marketplace barber</title>
-    <meta name="description" content="Sharings relie salons de coiffure et indépendants pour la location de postes." />
+    <title>Sharings — Réservez votre place dans les instituts</title>
+    <meta name="description" content="Sharings permet de réserver facilement un siège dans les instituts et de trouver les meilleurs prestataires." />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -12,8 +12,8 @@
   </head>
   <body class="sg-bg-base sg-text-black">
     <noscript>
-      <strong>Sharings — Marketplace barber</strong>
-      <p>Trouvez les meilleurs prestataires pour vos événements.</p>
+      <strong>Sharings — Réservez votre place</strong>
+      <p>Réservez facilement votre siège dans les instituts et trouvez les meilleurs prestataires pour vos événements.</p>
     </noscript>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,9 @@ import SignupPage from "./pages/SignupPage";
 import DashboardPage from "./pages/DashboardPage";
 import AnnoncesPage from "./pages/AnnoncesPage";
 import NewAnnoncePage from "./pages/NewAnnoncePage";
+import BookingPage from "./pages/BookingPage";
+import MessagingPage from "./pages/MessagingPage";
+import ContractPage from "./pages/ContractPage";
 import ProtectedRoute from "./components/ProtectedRoute";
 
 function ScrollToHash() {
@@ -30,6 +33,9 @@ export default function App() {
           <Route path="/dashboard" element={<DashboardPage />} />
           <Route path="/annonces" element={<AnnoncesPage />} />
           <Route path="/annonces/new" element={<NewAnnoncePage />} />
+          <Route path="/reservations" element={<BookingPage />} />
+          <Route path="/messages" element={<MessagingPage />} />
+          <Route path="/contrat" element={<ContractPage />} />
         </Route>
       </Routes>
     </>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -24,6 +24,9 @@ export default function Navbar() {
           {user ? (
             <>
               <NavLink to="/annonces" className={item}>Annonces</NavLink>
+              <NavLink to="/reservations" className={item}>Réservations</NavLink>
+              <NavLink to="/messages" className={item}>Messages</NavLink>
+              <NavLink to="/contrat" className={item}>Contrat</NavLink>
               <NavLink to="/dashboard" className={item}>Dashboard</NavLink>
               <button onClick={handleLogout} className={item}>Se déconnecter</button>
             </>
@@ -51,6 +54,9 @@ export default function Navbar() {
             {user ? (
               <>
                 <Link to="/annonces" onClick={() => setOpen(false)} className="sg-py-2">Annonces</Link>
+                <Link to="/reservations" onClick={() => setOpen(false)} className="sg-py-2">Réservations</Link>
+                <Link to="/messages" onClick={() => setOpen(false)} className="sg-py-2">Messages</Link>
+                <Link to="/contrat" onClick={() => setOpen(false)} className="sg-py-2">Contrat</Link>
                 <Link to="/dashboard" onClick={() => setOpen(false)} className="sg-py-2">Dashboard</Link>
                 <button onClick={handleLogout} className="sg-py-2 sg-text-left">Se déconnecter</button>
               </>

--- a/src/pages/BookingPage.tsx
+++ b/src/pages/BookingPage.tsx
@@ -1,0 +1,51 @@
+import { useState } from "react";
+
+export default function BookingPage() {
+  const [date, setDate] = useState("");
+  const [reservation, setReservation] = useState<{ date: string; time: string } | null>(null);
+  const times = [
+    "09:00",
+    "10:00",
+    "11:00",
+    "12:00",
+    "13:00",
+    "14:00",
+    "15:00",
+    "16:00",
+    "17:00",
+  ];
+
+  return (
+    <section className="sg-section">
+      <div className="sg-container">
+        <h2 className="sg-title-h2">Réserver un siège</h2>
+        <div className="sg-mt-4">
+          <input
+            type="date"
+            value={date}
+            onChange={e => setDate(e.target.value)}
+            className="sg-rounded-lg sg-border sg-border-black/20 sg-px-4 sg-py-2"
+          />
+        </div>
+        {date && (
+          <div className="sg-mt-4 sg-grid sg-grid-cols-2 sm:sg-grid-cols-4 sg-gap-3">
+            {times.map(t => (
+              <button
+                key={t}
+                onClick={() => setReservation({ date, time: t })}
+                className="sg-btn-primary"
+              >
+                {t}
+              </button>
+            ))}
+          </div>
+        )}
+        {reservation && (
+          <p className="sg-mt-6">
+            Vous avez réservé le {reservation.date} à {reservation.time}.
+          </p>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/pages/ContractPage.tsx
+++ b/src/pages/ContractPage.tsx
@@ -1,0 +1,54 @@
+import { useState } from "react";
+
+export default function ContractPage() {
+  const [salon, setSalon] = useState("");
+  const [pro, setPro] = useState("");
+  const [date, setDate] = useState("");
+  const [contract, setContract] = useState("");
+
+  const handleGenerate = (e: React.FormEvent) => {
+    e.preventDefault();
+    setContract(
+      `Contrat de réservation entre ${salon} et ${pro} pour le ${date}.\nLe professionnel s'engage à respecter les conditions du salon.`
+    );
+  };
+
+  return (
+    <section className="sg-section">
+      <div className="sg-container sg-max-w-xl">
+        <h2 className="sg-title-h2">Création de contrat</h2>
+        <form onSubmit={handleGenerate} className="sg-mt-4 sg-flex sg-flex-col sg-gap-4">
+          <input
+            required
+            placeholder="Nom du salon"
+            value={salon}
+            onChange={e => setSalon(e.target.value)}
+            className="sg-rounded-lg sg-border sg-border-black/20 sg-px-4 sg-py-2"
+          />
+          <input
+            required
+            placeholder="Nom du professionnel"
+            value={pro}
+            onChange={e => setPro(e.target.value)}
+            className="sg-rounded-lg sg-border sg-border-black/20 sg-px-4 sg-py-2"
+          />
+          <input
+            type="date"
+            required
+            value={date}
+            onChange={e => setDate(e.target.value)}
+            className="sg-rounded-lg sg-border sg-border-black/20 sg-px-4 sg-py-2"
+          />
+          <button type="submit" className="sg-btn-primary">
+            Générer le contrat
+          </button>
+        </form>
+        {contract && (
+          <pre className="sg-mt-6 sg-whitespace-pre-wrap sg-rounded-lg sg-border sg-border-black/10 sg-p-4">
+            {contract}
+          </pre>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -12,20 +12,20 @@ export default function LandingPage() {
       <section className="sg-section">
         <div className="sg-container sg-grid sg-items-center sg-gap-10 lg:sg-grid-cols-12">
           <div className="lg:sg-col-span-6">
-            <h1 className="sg-title-hero sg-max-w-[16ch] sg-font-serif">
-              Trouvez les <span className="sg-text-accent">meilleurs prestataires</span> pour vos événements
+            <h1 className="sg-title-hero sg-max-w-[18ch] sg-font-serif">
+              Réservez votre siège et trouvez les <span className="sg-text-accent">meilleurs prestataires</span>
             </h1>
             <p className="sg-text-lead sg-mt-4 sg-max-w-prose">
-              Sharings connecte salons de coiffure, indépendants et organisateurs d’événements pour créer des collaborations uniques et rentables.
+              Sharings connecte instituts, indépendants et organisateurs d’événements pour louer des places disponibles et créer des collaborations uniques et rentables.
             </p>
             <div className="sg-mt-6 sg-flex sg-flex-col sm:sg-flex-row sg-gap-3">
               <Link to="/signup?role=salon" className="sg-btn-primary">Je suis un Salon</Link>
               <Link to="/signup?role=indep" className="sg-btn-ghost">Je suis un Indépendant</Link>
             </div>
             <div className="sg-mt-6 sg-flex sg-flex-wrap sg-gap-2">
-              <span className="sg-chip">Réservations simples</span>
+              <span className="sg-chip">Réservation de sièges</span>
               <span className="sg-chip">Messagerie intégrée</span>
-              <span className="sg-chip">Support rapide</span>
+              <span className="sg-chip">Contrats simplifiés</span>
             </div>
           </div>
 

--- a/src/pages/MessagingPage.tsx
+++ b/src/pages/MessagingPage.tsx
@@ -1,0 +1,40 @@
+import { useState } from "react";
+
+export default function MessagingPage() {
+  const [messages, setMessages] = useState<string[]>([]);
+  const [input, setInput] = useState("");
+
+  const handleSend = () => {
+    if (!input.trim()) return;
+    setMessages([...messages, input]);
+    setInput("");
+  };
+
+  return (
+    <section className="sg-section">
+      <div className="sg-container sg-max-w-xl">
+        <h2 className="sg-title-h2">Messagerie</h2>
+        <div className="sg-mt-4 sg-border sg-border-black/10 sg-rounded-lg sg-p-4 sg-h-64 sg-overflow-y-auto">
+          {messages.length === 0 ? (
+            <p>Aucun message.</p>
+          ) : (
+            messages.map((m, i) => (
+              <div key={i} className="sg-mb-2">{m}</div>
+            ))
+          )}
+        </div>
+        <div className="sg-mt-4 sg-flex sg-gap-2">
+          <input
+            value={input}
+            onChange={e => setInput(e.target.value)}
+            placeholder="Votre message"
+            className="sg-flex-1 sg-rounded-lg sg-border sg-border-black/20 sg-px-4 sg-py-2"
+          />
+          <button onClick={handleSend} className="sg-btn-primary">
+            Envoyer
+          </button>
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- refactor landing and metadata to focus on seat reservations
- add simple booking, messaging and contract creation pages with routes
- update navbar and docs

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build` (fails: vite not found)
- `npm install --no-fund --no-audit` (fails: 403 Forbidden - GET https://registry.npmjs.org/@prisma%2fclient)


------
https://chatgpt.com/codex/tasks/task_e_689f5ecf66608327900405badc828383