### PR TITLE
Add preferences management and notifications tests

### DIFF
--- a/README_FONCTIONS_TESTS.md
+++ b/README_FONCTIONS_TESTS.md
@@ -1,0 +1,27 @@
+# Fonctions & Tests
+
+## Préférences
+- Page: `/account` → composant `PreferencesForm`
+- Sauvegarde en table `user_preferences` (RLS: owner-only)
+
+## Recherche
+- Page: `/search` (autocomplete villes, filtres services/budget, cartes)
+- Bouton **Créer une alerte** → `saved_searches` (mock de notification en dev)
+
+## Relances / Alertes (dev)
+SUPABASE_URL=... SERVICE_ROLE_KEY=... npx ts-node scripts/notify_saved_searches.ts
+
+shell
+Copier
+Modifier
+Affiche en console les “emails” qui seraient envoyés.
+
+## Tests
+npm run test:api
+npx playwright install
+npm run test:e2e
+
+bash
+Copier
+Modifier
+Astuce: si l’inscription UI n’existe pas encore, le test E2E crée un utilisateur via l’API admin, puis teste recherche + sauvegarde.

--- a/scripts/notify_saved_searches.ts
+++ b/scripts/notify_saved_searches.ts
@@ -1,0 +1,27 @@
+import { createClient } from "@supabase/supabase-js";
+const supa = createClient(process.env.SUPABASE_URL!, process.env.SERVICE_ROLE_KEY!);
+
+function match(biz:any, q:any){
+  if (q.cityId && biz.city_id !== q.cityId) return false;
+  if (q.services?.length && !q.services.every((s:string)=>biz.tags?.includes(s))) return false;
+  if (q.q && !(`${biz.name}`.toLowerCase()).includes(q.q.toLowerCase())) return false;
+  if (q.priceMax && biz.price_max > q.priceMax) return false;
+  return true;
+}
+
+(async () => {
+  // 1) récupérer recherches
+  const { data: searches, error } = await supa.from("saved_searches").select("id,user_id,query");
+  if (error) throw error;
+
+  // 2) pour chaque, chercher des nouveautés (ici: top 10)
+  for (const s of searches ?? []) {
+    const { data: biz } = await supa.from("businesses").select("*").limit(50);
+    const hits = (biz ?? []).filter(b => match(b, s.query));
+    if (hits.length) {
+      // mock "email"
+      console.log(`[ALERTE] user=${s.user_id} | recherche=${s.id} | ${hits.length} résultats`);
+    }
+  }
+  console.log("notify_saved_searches OK");
+})().catch(e => { console.error(e); process.exit(1); });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { Routes, Route } from "react-router-dom";
 import LandingPage from "./pages/LandingPage";
 import SearchPage from "./pages/SearchPage";
+import AccountPage from "./pages/AccountPage";
 
 const Login = () => <div className="section container-page">Login</div>;
 const Signup = () => <div className="section container-page">Signup</div>;
@@ -10,6 +11,7 @@ export default function App() {
     <Routes>
       <Route path="/" element={<LandingPage />} />
       <Route path="/search" element={<SearchPage />} />
+      <Route path="/account" element={<AccountPage />} />
       <Route path="/login" element={<Login />} />
       <Route path="/signup" element={<Signup />} />
     </Routes>

--- a/src/features/preferences/PreferencesForm.tsx
+++ b/src/features/preferences/PreferencesForm.tsx
@@ -1,0 +1,117 @@
+import { useEffect, useState } from "react";
+import { supa } from "../../lib/supa";
+import { getCities } from "../../lib/search";
+
+export default function PreferencesForm() {
+  const [me, setMe] = useState<string | null>(null);
+  const [cityInput, setCityInput] = useState("");
+  const [cities, setCities] = useState<{id:string;name:string}[]>([]);
+  const [selectedCities, setSelectedCities] = useState<string[]>([]);
+  const [services, setServices] = useState<string[]>([]);
+  const [radius, setRadius] = useState(15);
+  const [budget, setBudget] = useState([30, 120]);
+  const [notifications, setNotifications] = useState(true);
+
+  useEffect(() => { (async () => {
+    const u = (await supa.auth.getUser()).data.user;
+    if (!u) return;
+    setMe(u.id);
+    const { data } = await supa.from("user_preferences").select("*").eq("user_id", u.id).single();
+    if (data) {
+      setSelectedCities(data.cities || []);
+      setServices(data.services || []);
+      setRadius(data.radius_km || 15);
+      setBudget([data.budget_min ?? 30, data.budget_max ?? 120]);
+      setNotifications(!!data.notifications);
+    }
+  })(); }, []);
+
+  useEffect(() => { (async () => {
+    if (cityInput.trim().length < 2) { setCities([]); return; }
+    setCities(await getCities(cityInput.trim()));
+  })(); }, [cityInput]);
+
+  async function save() {
+    if (!me) return alert("Connectez-vous.");
+    const { error } = await supa.from("user_preferences").upsert({
+      user_id: me,
+      cities: selectedCities,
+      services,
+      radius_km: radius,
+      budget_min: budget[0],
+      budget_max: budget[1],
+      notifications
+    });
+    if (error) return alert(error.message);
+    alert("Préférences enregistrées ✅");
+  }
+
+  return (
+    <div className="card">
+      <h3 className="text-lg font-semibold">Mes préférences</h3>
+
+      <div className="mt-4">
+        <label className="text-sm text-white/70">Villes favorites</label>
+        <input
+          className="mt-1 w-full rounded-xl bg-white/5 border border-white/10 px-3 py-2"
+          placeholder="Paris, Lyon…"
+          value={cityInput}
+          onChange={(e)=>setCityInput(e.target.value)}
+        />
+        {cities.length>0 && (
+          <div className="mt-2 bg-base border border-white/10 rounded-xl p-2 max-h-56 overflow-auto">
+            {cities.map(c => (
+              <button key={c.id} className="block w-full text-left px-2 py-1 rounded hover:bg-white/5"
+                onClick={()=>{ if (!selectedCities.includes(c.id)) setSelectedCities([...selectedCities, c.id]); setCityInput(""); setCities([]); }}>
+                {c.name}
+              </button>
+            ))}
+          </div>
+        )}
+        {selectedCities.length>0 && (
+          <div className="mt-2 flex flex-wrap gap-2">
+            {selectedCities.map(id => (
+              <span key={id} className="chip">{id.slice(0,6)}<button className="ml-2" onClick={()=>setSelectedCities(selectedCities.filter(x=>x!==id))}>×</button></span>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="mt-4">
+        <label className="text-sm text-white/70">Services</label>
+        <div className="mt-2 flex flex-wrap gap-2">
+          {["coupe","coloration","barbe","manucure","épilation","massage"].map(s => (
+            <button key={s}
+              onClick={()=>setServices(prev => prev.includes(s) ? prev.filter(x=>x!==s) : [...prev, s])}
+              className={`chip ${services.includes(s) ? "bg-white/20" : ""}`}>
+              {s}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="mt-4 grid sm:grid-cols-2 gap-4">
+        <div>
+          <label className="text-sm text-white/70">Rayon (km)</label>
+          <input type="range" min={5} max={100} value={radius} onChange={e=>setRadius(+e.target.value)} className="w-full"/>
+          <div className="text-white/70 text-sm mt-1">{radius} km</div>
+        </div>
+        <div>
+          <label className="text-sm text-white/70">Budget (min–max €)</label>
+          <input type="range" min={10} max={200} value={budget[1]} onChange={e=>setBudget([budget[0], +e.target.value])} className="w-full"/>
+          <div className="text-white/70 text-sm mt-1">{budget[0]}–{budget[1]} €</div>
+        </div>
+      </div>
+
+      <label className="mt-4 flex items-center gap-2">
+        <input type="checkbox" checked={notifications} onChange={e=>setNotifications(e.target.checked)} />
+        Recevoir des alertes (mock en dev)
+      </label>
+
+      <div className="mt-6 flex gap-3">
+        <button className="btn-primary" onClick={save}>Enregistrer</button>
+      </div>
+    </div>
+  );
+}
+

--- a/src/pages/AccountPage.tsx
+++ b/src/pages/AccountPage.tsx
@@ -1,0 +1,19 @@
+import PreferencesForm from "../features/preferences/PreferencesForm";
+import Navbar from "../components/Navbar";
+
+export default function AccountPage() {
+  return (
+    <>
+      <Navbar />
+      <section className="section">
+        <div className="container-page">
+          <h1 className="title-h2">Mon compte</h1>
+          <p className="text-white/80 mt-2">Gérez vos préférences et vos alertes.</p>
+          <div className="mt-6 grid gap-6">
+            <PreferencesForm />
+          </div>
+        </div>
+      </section>
+    </>
+  );
+}

--- a/tests/api/prefs-and-search.spec.ts
+++ b/tests/api/prefs-and-search.spec.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from "vitest";
+import { supa } from "../../src/lib/supa";
+import { getCities, searchBusinesses } from "../../src/lib/search";
+
+describe("prefs + search", () => {
+  it("autocomplete villes FR", async () => {
+    const r = await getCities("Par");
+    expect(r.length).toBeGreaterThan(0);
+  });
+
+  it("recherche retourne des cartes", async () => {
+    const { data } = await searchBusinesses({ q: "coupe", page: 1 });
+    expect(Array.isArray(data)).toBe(true);
+  });
+});

--- a/tests/e2e/full-flow.spec.ts
+++ b/tests/e2e/full-flow.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect } from "@playwright/test";
+import { createClient } from "@supabase/supabase-js";
+
+test("inscription → préférences → recherche → sauvegarde", async ({ page }) => {
+  // crée un user directement (admin) pour éviter l'email provider en dev
+  const admin = createClient(process.env.SUPABASE_URL!, process.env.SERVICE_ROLE_KEY!);
+  const email = `qa+${Date.now()}@example.com`;
+  const pass = "Test!123456";
+  await admin.auth.admin.createUser({ email, password: pass, email_confirm: true });
+
+  // login UI (si tu as un écran dédié, adapte les sélecteurs)
+  await page.goto("/account");
+
+  // préférences (sélection d'une ville)
+  await page.goto("/search");
+  await page.getByPlaceholder("Paris, Lyon…").fill("Par");
+  await page.waitForTimeout(400);
+  await page.locator("text=Paris").first().click();
+  await page.getByPlaceholder("coupe, coloration…").fill("coupe");
+  await page.locator("text=coupe").first().click();
+
+  // sauvegarde
+  await page.locator("text=Créer une alerte").click();
+  await expect(page).toHaveTitle(/Sharings/i);
+});


### PR DESCRIPTION
## Summary
- Add user PreferencesForm for favorite cities, services, radius, budget and alerts
- Introduce account page and /account route
- Add notification mock script and tests for preferences search flow

## Testing
- `npm run test:api` *(fails: vitest: not found)*
- `npm run test:e2e` *(fails: playwright: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f985fcbd083279a017d9c519b1437