### PR TITLE
Add landing page utilities and carousel components

### DIFF
--- a/src/assets/landingImages.ts
+++ b/src/assets/landingImages.ts
@@ -1,29 +1,5 @@
-codex/add-background-carousel-and-styling-components
-import type { Slide } from "../components/BackgroundCarousel";
-
-export const HERO_BG_IMAGES: Slide[] = [
-  {
-    src: "/hero/1.jpg",
-    srcSet: "/hero/1.jpg 800w, /hero/1.jpg 1200w, /hero/1.jpg 1600w",
-    alt: "Ambiance chaleureuse en salon",
-    objectPosition: "center",
-  },
-  {
-    src: "/hero/2.jpg",
-    srcSet: "/hero/2.jpg 800w, /hero/2.jpg 1200w, /hero/2.jpg 1600w",
-    alt: "Poste de coiffure moderne",
-    objectPosition: "center",
-  },
-  {
-    src: "/hero/3.jpg",
-    srcSet: "/hero/3.jpg 800w, /hero/3.jpg 1200w, /hero/3.jpg 1600w",
-    alt: "Équipe professionnelle en action",
-    objectPosition: "center",
-  },
-];
 export const HERO_BG_IMAGES = [
   { src: "/hero/1.jpg", srcSet: "/hero/1.jpg 800w, /hero/1.jpg 1200w, /hero/1.jpg 1600w", alt: "Ambiance chaleureuse en salon", objectPosition: "center" },
   { src: "/hero/2.jpg", srcSet: "/hero/2.jpg 800w, /hero/2.jpg 1200w, /hero/2.jpg 1600w", alt: "Poste de coiffure moderne", objectPosition: "center" },
   { src: "/hero/3.jpg", srcSet: "/hero/3.jpg 800w, /hero/3.jpg 1200w, /hero/3.jpg 1600w", alt: "Équipe professionnelle en action", objectPosition: "center" },
 ] as const;
-main

--- a/src/components/BackgroundCarousel.tsx
+++ b/src/components/BackgroundCarousel.tsx
@@ -1,26 +1,10 @@
 import { useEffect, useRef, useState } from "react";
 
-codex/add-background-carousel-and-styling-components
-export type Slide = { src: string; srcSet?: string; alt?: string; objectPosition?: string };
+type Slide = { src: string; srcSet?: string; alt?: string; objectPosition?: string };
 
 export default function BackgroundCarousel({
   images, intervalMs = 6000, className = "", pauseOnHover = false
 }: { images: Slide[]; intervalMs?: number; className?: string; pauseOnHover?: boolean; }) {
-
-type Slide = { src: string; srcSet?: string; alt?: string; objectPosition?: string };
-
-export default function BackgroundCarousel({
-  images,
-  intervalMs = 6000,
-  className = "",
-  pauseOnHover = false,
-}: {
-  images: Slide[];
-  intervalMs?: number;
-  className?: string;
-  pauseOnHover?: boolean;
-}) {
- main
   const [i, setI] = useState(0);
   const [fade, setFade] = useState(false);
   const timer = useRef<number | null>(null);
@@ -31,20 +15,12 @@ export default function BackgroundCarousel({
     const run = () => {
       timer.current = window.setInterval(() => {
         setFade(true);
- codex/add-background-carousel-and-styling-components
         window.setTimeout(() => { setI((p) => (p + 1) % images.length); setFade(false); }, 250);
-
-        window.setTimeout(() => {
-          setI((p) => (p + 1) % images.length);
-          setFade(false);
-        }, 250);
- main
       }, intervalMs);
     };
     run();
     const el = ref.current;
     if (pauseOnHover && el) {
- codex/add-background-carousel-and-styling-components
       const stop = () => { if (timer.current) window.clearInterval(timer.current); };
       const start = () => run();
       el.addEventListener("mouseenter", stop);
@@ -52,22 +28,6 @@ export default function BackgroundCarousel({
       return () => { stop(); el.removeEventListener("mouseenter", stop); el.removeEventListener("mouseleave", start); };
     }
     return () => { if (timer.current) window.clearInterval(timer.current); };
-      const stop = () => {
-        if (timer.current) window.clearInterval(timer.current);
-      };
-      const start = () => run();
-      el.addEventListener("mouseenter", stop);
-      el.addEventListener("mouseleave", start);
-      return () => {
-        stop();
-        el.removeEventListener("mouseenter", stop);
-        el.removeEventListener("mouseleave", start);
-      };
-    }
-    return () => {
-      if (timer.current) window.clearInterval(timer.current);
-    };
- main
   }, [images.length, intervalMs, pauseOnHover]);
 
   const cur = images[i];
@@ -84,19 +44,9 @@ export default function BackgroundCarousel({
           decoding="async"
           className={`h-full w-full object-cover transition-opacity duration-700 ease-in-out ${fade ? "opacity-0" : "opacity-100"}`}
           style={{ objectPosition: cur.objectPosition ?? "center" }}
- codex/add-background-carousel-and-styling-components
           onError={(e) => { (e.currentTarget as HTMLImageElement).style.display = "none"; }}
-
-          onError={(e) => {
-            (e.currentTarget as HTMLImageElement).style.display = "none";
-          }}
- main
         />
       </picture>
     </div>
   );
 }
- codex/add-background-carousel-and-styling-components
-
-=======
- main

--- a/src/components/FeatureCard.tsx
+++ b/src/components/FeatureCard.tsx
@@ -1,18 +1,6 @@
 import { ReactNode } from "react";
 
- codex/add-background-carousel-and-styling-components
 export default function FeatureCard({icon, title, children}:{icon:ReactNode; title:string; children:ReactNode;}){
-
-export default function FeatureCard({
-  icon,
-  title,
-  children,
-}: {
-  icon: ReactNode;
-  title: string;
-  children: ReactNode;
-}) {
- main
   return (
     <div className="card hover:shadow-xl transition">
       <div className="text-2xl mb-3">{icon}</div>
@@ -21,7 +9,3 @@ export default function FeatureCard({
     </div>
   );
 }
- codex/add-background-carousel-and-styling-components
-
-
- main

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,8 +1,4 @@
- codex/add-background-carousel-and-styling-components
 export default function Footer(){
-
-export default function Footer() {
- main
   return (
     <footer className="mt-16 border-t border-white/10">
       <div className="container-page py-8 text-sm text-white/60 flex flex-col sm:flex-row items-center justify-between gap-3">
@@ -16,7 +12,3 @@ export default function Footer() {
     </footer>
   );
 }
- codex/add-background-carousel-and-styling-components
-
-=======
- main

--- a/src/components/StickyActions.tsx
+++ b/src/components/StickyActions.tsx
@@ -1,10 +1,6 @@
 import { Link } from "react-router-dom";
 
- codex/add-background-carousel-and-styling-components
 export default function StickyActions(){
-
-export default function StickyActions() {
- main
   return (
     <div className="fixed inset-x-0 bottom-4 z-40 px-4 sm:hidden">
       <div className="mx-auto max-w-md rounded-2xl border border-white/10 bg-black/60 backdrop-blur p-2 flex gap-2">
@@ -14,5 +10,3 @@ export default function StickyActions() {
     </div>
   );
 }
- codex/add-background-carousel-and-styling-components
- main

--- a/src/components/__tests__/BackgroundCarousel.test.tsx
+++ b/src/components/__tests__/BackgroundCarousel.test.tsx
@@ -1,7 +1,3 @@
- codex/add-background-carousel-and-styling-components
-
-/* @vitest-environment jsdom */
- main
 import { describe, it, expect, vi } from "vitest";
 import { render } from "@testing-library/react";
 import BackgroundCarousel from "../BackgroundCarousel";
@@ -10,19 +6,9 @@ vi.useFakeTimers();
 
 describe("BackgroundCarousel", () => {
   it("renders first image and auto-rotates", () => {
- codex/add-background-carousel-and-styling-components
     const { container } = render(<BackgroundCarousel images={[{src:"/hero/1.jpg"},{src:"/hero/2.jpg"}]} intervalMs={1000} />);
-
-    const { container } = render(
-      <BackgroundCarousel images={[{ src: "/hero/1.jpg" }, { src: "/hero/2.jpg" }]} intervalMs={1000} />
-    );
- main
     expect(container.querySelector("img")?.getAttribute("src")).toBe("/hero/1.jpg");
     vi.advanceTimersByTime(1500);
     expect(container.querySelector("img")?.getAttribute("src")).toBe("/hero/2.jpg");
   });
 });
- codex/add-background-carousel-and-styling-components
-
-=======
- main

--- a/src/index.css
+++ b/src/index.css
@@ -19,13 +19,9 @@ body { @apply bg-base text-white antialiased font-sans; }
   .drop-shadow-hero { filter: drop-shadow(0 10px 24px rgba(0,0,0,.35)); }
   @media (prefers-reduced-motion: no-preference) {
     .reveal { opacity: 0; transform: translateY(16px); animation: r .6s ease-out forwards; }
- codex/add-background-carousel-and-styling-components
     .delay-150 { animation-delay: .15s; }
     .delay-300 { animation-delay: .3s; }
     .delay-500 { animation-delay: .5s; }
-
-    .delay-150 { animation-delay: .15s; } .delay-300 { animation-delay: .3s; } .delay-500 { animation-delay: .5s; }
- main
     @keyframes r { to { opacity: 1; transform: translateY(0) } }
   }
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -9,10 +9,6 @@ export default {
         accent: "#ef4444",
         surface: "rgba(255,255,255,0.04)",
         border: "rgba(255,255,255,0.12)",
- codex/add-background-carousel-and-styling-components
-
-        ink: "#eaeef6",
- main
       },
       boxShadow: { soft: "0 8px 30px rgba(0,0,0,.18)" },
       fontFamily: {


### PR DESCRIPTION
## Summary
- restore tailwind theme colors and fonts
- add landing page utility classes and UI components
- include background carousel unit test

## Testing
- `npm test -- --run` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6362f890083278cf5c352c47c0c8e