### PR TITLE
fix(netlify): move headers/redirects to public/ and stabilize build checks

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,6 +3,5 @@
   publish = "dist"
   [build.environment]
     NODE_VERSION = "20.11.1"
-    NPM_FLAGS = "--no-fund --no-audit"
 
 # NOTE: Les règles sont désormais fournies par public/_headers et public/_redirects. 


### PR DESCRIPTION
## Summary
- relocate Netlify headers and redirects into `public/`
- streamline Netlify build config with explicit Node 20.11.1

## Testing
- `npm ci --no-audit --no-fund` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@playwright%2ftest)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a86fac4f30832793fcb3be9e927870