### PR TITLE
Remove nested BrowserRouter

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter, Routes, Route } from "react-router-dom"
+import { Routes, Route } from "react-router-dom"
 import LandingPage from "./pages/LandingPage"
 import LoginPage from "./pages/LoginPage"
 import SignupPage from "./pages/SignupPage"
@@ -10,17 +10,15 @@ import ContractPage from "./pages/ContractPage"
 
 export default function App() {
   return (
-    <BrowserRouter>
-      <Routes>
-        <Route path="/" element={<LandingPage />} />
-        <Route path="/login" element={<LoginPage />} />
-        <Route path="/register" element={<SignupPage />} />
-        <Route path="/recherche" element={<SearchPage />} />
-        <Route path="/creer-annonce" element={<NewAnnoncePage />} />
-        <Route path="/reservations" element={<BookingPage />} />
-        <Route path="/messages" element={<MessagingPage />} />
-        <Route path="/contrat" element={<ContractPage />} />
-      </Routes>
-    </BrowserRouter>
+    <Routes>
+      <Route path="/" element={<LandingPage />} />
+      <Route path="/login" element={<LoginPage />} />
+      <Route path="/register" element={<SignupPage />} />
+      <Route path="/recherche" element={<SearchPage />} />
+      <Route path="/creer-annonce" element={<NewAnnoncePage />} />
+      <Route path="/reservations" element={<BookingPage />} />
+      <Route path="/messages" element={<MessagingPage />} />
+      <Route path="/contrat" element={<ContractPage />} />
+    </Routes>
   )
 }


### PR DESCRIPTION
## Summary
- remove nested `<BrowserRouter>` wrapping `Routes` in `App` to avoid double-router error

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden fetching @playwright/test)*

------
https://chatgpt.com/codex/tasks/task_e_68ab2bfdd6188327a5bb33a13a7250b7