### PR TITLE
feat: refresh landing page design

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,9 @@
 <html lang="fr">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <!-- Preload 1ère image du hero pour un meilleur LCP -->
+    <link rel="preload" as="image" href="https://images.unsplash.com/photo-1522335789203-aabd1fc54bc9?q=80&w=2000&auto=format&fit=crop" />
     <title>Sharings — Réservez votre place dans les instituts</title>
     <meta name="description" content="Sharings permet de réserver facilement un siège dans les instituts et de trouver les meilleurs prestataires." />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />

--- a/public/_headers
+++ b/public/_headers
@@ -1,11 +1,12 @@
-/* 
+/*
   X-Frame-Options: SAMEORIGIN
   X-Content-Type-Options: nosniff
   Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
   X-XSS-Protection: 1; mode=block
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: geolocation=(), camera=(), microphone=()
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; connect-src 'self' https://*.supabase.co https://*.supabase.in; font-src 'self' https: data:; frame-ancestors 'self';
+  # Autorise Unsplash et toutes images https pour le carrousel (corrige les "?" sur iPhone)
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https: https://images.unsplash.com https://*.unsplash.com; connect-src 'self' https://*.supabase.co https://*.supabase.in; font-src 'self' https: data:; frame-ancestors 'self';
 
 /assets/*
   Cache-Control: public, max-age=31536000, immutable

--- a/src/components/BackgroundCarousel.tsx
+++ b/src/components/BackgroundCarousel.tsx
@@ -1,58 +1,58 @@
-import { useEffect, useRef, useState } from "react"
+import { useEffect, useRef, useState } from "react";
 
-export type Slide = {
-  src: string
-  alt?: string
-  srcSet?: string
-  objectPosition?: string
-}
+export type Image = {
+  src: string;
+  alt?: string;
+  srcSet?: string;
+  objectPosition?: string;
+};
 
 interface Props {
-  slides: Slide[]
-  intervalMs?: number
-  pauseOnHover?: boolean
-  className?: string
+  images: Image[];
+  intervalMs?: number;
+  pauseOnHover?: boolean;
+  className?: string;
 }
 
 export default function BackgroundCarousel({
-  slides,
+  images,
   intervalMs = 5000,
   pauseOnHover = true,
   className = "",
 }: Props) {
-  const [idx, setIdx] = useState(0)
-  const timer = useRef<number | null>(null)
-  const paused = useRef(false)
+  const [index, setIndex] = useState(0);
+  const timer = useRef<number | null>(null);
+  const paused = useRef(false);
 
   useEffect(() => {
-    start()
-    return stop
+    start();
+    return stop;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [slides.length, intervalMs])
+  }, [images.length, intervalMs]);
 
   function start() {
-    stop()
+    stop();
     timer.current = window.setInterval(() => {
       if (!paused.current) {
-        setIdx((i) => (i + 1) % slides.length)
+        setIndex((i) => (i + 1) % images.length);
       }
-    }, intervalMs)
+    }, intervalMs);
   }
 
   function stop() {
     if (timer.current) {
-      window.clearInterval(timer.current)
-      timer.current = null
+      window.clearInterval(timer.current);
+      timer.current = null;
     }
   }
 
   return (
     <div
-      className={`relative h-full w-full overflow-hidden ${className}`}
+      className={`absolute inset-0 overflow-hidden ${className}`}
       onMouseEnter={() => pauseOnHover && (paused.current = true)}
       onMouseLeave={() => pauseOnHover && (paused.current = false)}
     >
-      {slides.map((s, i) => (
+      {images.map((s, i) => (
         <img
           key={s.src + i}
           src={s.src}
@@ -62,12 +62,12 @@ export default function BackgroundCarousel({
           loading={i === 0 ? "eager" : "lazy"}
           fetchPriority={i === 0 ? "high" : "auto"}
           style={{ objectPosition: s.objectPosition }}
-          className={`absolute inset-0 h-full w-full object-cover transition-opacity duration-700 ${
-            i === idx ? "opacity-100" : "opacity-0"
+          className={`absolute inset-0 h-full w-full object-cover transition-opacity duration-700 will-change-[opacity] ${
+            i === index ? "opacity-100" : "opacity-0"
           }`}
         />
       ))}
-      <div className="pointer-events-none absolute inset-0 bg-gradient-to-b from-black/70 via-black/40 to-black/80" />
+      <div className="absolute inset-0 bg-black/50" />
     </div>
-  )
+  );
 }

--- a/src/components/HeroBackgroundCarousel.tsx
+++ b/src/components/HeroBackgroundCarousel.tsx
@@ -1,10 +1,10 @@
-import BackgroundCarousel, { type Slide } from "./BackgroundCarousel";
+import BackgroundCarousel, { type Image } from "./BackgroundCarousel";
 
 type Props = {
-  images: Slide[];
+  images: Image[];
   intervalMs?: number;
 };
 
 export default function HeroBackgroundCarousel({ images, intervalMs }: Props) {
-  return <BackgroundCarousel slides={images} intervalMs={intervalMs} />;
+  return <BackgroundCarousel images={images} intervalMs={intervalMs} />;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -3,21 +3,37 @@
 @tailwind utilities;
 
 html { scroll-behavior: smooth; }
+body { 
+  @apply bg-base text-ink;
+}
 .container-page { @apply mx-auto max-w-7xl px-4 sm:px-6 lg:px-8; }
 .section { @apply py-10 sm:py-14 lg:py-20; }
-.title-hero { font-size: clamp(2rem, 6vw, 4rem); @apply font-bold leading-tight; }
-.title-h2 { font-size: clamp(1.5rem, 4.5vw, 2.2rem); @apply font-semibold; }
-.text-lead { @apply text-base sm:text-lg text-white/80; }
-.card { @apply rounded-2xl border border-white/10 bg-white/5 backdrop-blur p-5 sm:p-6 shadow-lg; }
-.btn { @apply inline-flex items-center justify-center rounded-xl px-5 py-3 font-medium transition min-h-[48px] focus:outline-none focus:ring-2 focus:ring-white/30; }
-.btn-primary { @apply bg-white text-black hover:opacity-90 active:opacity-80; }
-.btn-ghost { @apply border border-white/20 text-white hover:bg-white/5; }
-.chip { @apply inline-flex items-center rounded-full px-3 py-1 text-sm border border-white/10 bg-white/5; }
+.title-hero { font-size: clamp(2.2rem, 6vw, 4rem); @apply font-serif font-bold leading-tight text-ink; }
+.title-h2 { font-size: clamp(1.6rem, 4.5vw, 2.2rem); @apply font-semibold text-ink; }
+.text-lead { @apply text-base sm:text-lg text-inkMuted; }
+
+/* Cartes et surfaces */
+.card    { @apply rounded-2xl border border-transparent bg-surface shadow-card p-5 sm:p-6; }
+.cardAlt { @apply rounded-2xl border border-line bg-surfaceAlt shadow-soft p-5 sm:p-6; }
+.muted   { @apply text-inkMuted; }
+
+/* Boutons */
+.btn { @apply inline-flex items-center justify-center rounded-xl px-5 py-3 font-semibold transition min-h-[48px] focus:outline-none focus:ring-2 focus:ring-offset-2; }
+.btn-primary { @apply bg-brand-primary text-white shadow-cta hover:bg-brand-primaryDark focus:ring-brand-primary; }
+.btn-ghost   { @apply border border-line text-ink hover:bg-surfaceAlt; }
+.btn-light   { @apply bg-white text-ink border border-line hover:bg-surfaceAlt shadow-soft; }
+.glow { box-shadow: 0 0 30px rgba(255,56,92,.25); }
+
+/* iOS safe area + viewport réel */
+.pt-safe-top { padding-top: env(safe-area-inset-top); }
+.h-dvh { height: 100dvh; }
 
 @layer utilities {
   .drop-shadow-hero { filter: drop-shadow(0 10px 30px rgba(0,0,0,.5)); }
   .pt-safe-top { padding-top: env(safe-area-inset-top); }
   .reveal { @apply opacity-0 translate-y-2; }
   .reveal.in { @apply opacity-100 translate-y-0; transition: all .2s; }
-  .gradient-text { @apply bg-clip-text text-transparent; background-image: linear-gradient(90deg, #60a5fa, #c4b5fd, #f9a8d4); }
+  .gradient-text { @apply bg-clip-text text-transparent; background-image: linear-gradient(90deg,#60a5fa,#c4b5fd,#f9a8d4); }
+  .navbar-glass { @apply sticky top-0 z-40 backdrop-blur bg-white/70 border-b border-line; }
+  .hero-over * { @apply text-white; }
 }

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -1,7 +1,4 @@
-import { Link } from "react-router-dom";
-import HeroBackgroundCarousel from "../components/HeroBackgroundCarousel";
-import TechGlow from "../components/TechGlow";
-import NeonButton from "../components/NeonButton";
+import HeroBackgroundCarousel from "../components/BackgroundCarousel";
 
 const HERO_IMAGES = [
   {
@@ -20,140 +17,62 @@ const HERO_IMAGES = [
 
 export default function LandingPage() {
   return (
-    <div className="min-h-screen bg-neutral-950 text-white relative">
-      <TechGlow />
-      {/* NAV */}
-      <header className="sticky top-0 z-40 border-b border-white/10 bg-neutral-950/60 backdrop-blur">
-        <nav className="mx-auto flex max-w-7xl items-center justify-between px-4 py-3">
-          <Link to="/" className="text-xl font-semibold tracking-tight hover:opacity-90">
-            Sharings
-          </Link>
-          <div className="hidden gap-6 md:flex">
-            <a href="#features" className="text-white/80 hover:text-white">
-              Fonctionnalités
-            </a>
-            <a href="#how" className="text-white/80 hover:text-white">
-              Comment ça marche
-            </a>
-            <Link to="/recherche" className="text-white/80 hover:text-white">
-              Rechercher
-            </Link>
-          </div>
-          <div className="flex items-center gap-2">
-            <Link
-              to="/login"
-              className="rounded-xl border border-white/15 px-4 py-2 text-sm hover:bg-white/5"
-            >
-              Se connecter
-            </Link>
-            <NeonButton to="/register">Créer un compte</NeonButton>
-          </div>
-        </nav>
+    <main className="relative bg-base">
+      {/* NAV "verre" */}
+      <header className="navbar-glass">
+        <div className="container-page flex h-14 items-center justify-between">
+          <a href="/" className="font-semibold">Sharings</a>
+          <nav className="hidden sm:flex items-center gap-3">
+            <a href="/login" className="btn btn-light">Se connecter</a>
+            <a href="/register" className="btn btn-primary">Créer un compte</a>
+          </nav>
+        </div>
       </header>
 
-      {/* HERO */}
-      <section className="relative h-[86svh] overflow-hidden">
+      {/* HERO plein écran (texte blanc sur image) */}
+      <section className="relative h-dvh sm:min-h-[82vh]">
         <HeroBackgroundCarousel images={HERO_IMAGES} intervalMs={5500} />
-        <div className="relative z-10 mx-auto flex h-full max-w-7xl items-center px-4">
+        <div className="container-page relative z-10 flex h-full items-end sm:items-center pt-safe-top pb-10 hero-over">
           <div className="max-w-2xl">
-            <p className="mb-3 inline-flex items-center rounded-full border border-white/15 bg-white/10 px-3 py-1 text-xs text-white/80 backdrop-blur">
-              Nouveau • Marketplace coiffure & esthétique
-            </p>
-            <h1 className="title-hero drop-shadow-hero leading-[1.05]">
-              Réservez un siège, trouvez <span className="gradient-text">les meilleurs prestataires</span>
-            </h1>
-            <p className="text-lead mt-4 max-w-xl">
-              Salons, indépendants & organisateurs : louez des places disponibles, collaborez en toute simplicité et sécurisez vos échanges.
-            </p>
-            <div className="mt-6 flex flex-col gap-3 sm:flex-row">
-              <NeonButton to="/creer-annonce">Je suis un Salon</NeonButton>
-              <NeonButton to="/recherche" variant="ghost">
-                Je suis un Indépendant
-              </NeonButton>
-            </div>
-            <div className="mt-5 flex flex-wrap gap-2 text-sm text-white/70">
-              <span className="chip">Réservation de sièges</span>
-              <span className="chip">Messagerie intégrée</span>
-              <span className="chip">Contrats simplifiés</span>
+            <h1 className="title-hero drop-shadow-hero text-white">Réservez votre siège et trouvez les meilleurs prestataires</h1>
+            <p className="mt-4 text-lead text-white/90">Sharings connecte instituts, indépendants et organisateurs d’événements pour louer des places disponibles et créer des collaborations uniques.</p>
+            <div className="mt-6 grid gap-3 sm:flex">
+              <a href="/register" className="btn btn-primary glow w-full sm:w-auto">Créer un compte</a>
+              <a href="/recherche" className="btn btn-light w-full sm:w-auto">Voir les annonces</a>
             </div>
           </div>
         </div>
       </section>
 
-      {/* POURQUOI */}
-      <section id="features" className="section container-page">
-        <h2 className="title-h2 mb-6">Pourquoi Sharings</h2>
-        <div className="grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
-          {[
-            {
-              title: "Gagnez du temps",
-              text: "Des recherches ciblées, des réponses rapides et un planning clair.",
-            },
-            {
-              title: "Revenus boostés",
-              text: "Rentabilisez vos espaces vacants en quelques clics.",
-            },
-            {
-              title: "Sécurité assurée",
-              text: "Profils vérifiés, contrats et messagerie intégrés.",
-            },
-          ].map((c) => (
-            <div key={c.title} className="card hover:shadow-2xl transition">
-              <h3 className="mb-2 text-lg font-semibold gradient-text">{c.title}</h3>
-              <p className="text-white/75">{c.text}</p>
-            </div>
-          ))}
-        </div>
-      </section>
-
-      {/* COMMENT */}
       <section id="how" className="section container-page">
-        <h2 className="title-h2 mb-6">Comment ça marche</h2>
-        <ol className="grid gap-5 sm:grid-cols-3">
-          {[
-            { step: "1", text: "Créez votre compte (salon ou indépendant)." },
-            { step: "2", text: "Publiez une annonce ou recherchez une place." },
-            {
-              step: "3",
-              text: "Réservez, échangez par message, signez le contrat.",
-            },
-          ].map((s) => (
-            <li key={s.step} className="card">
-              <span className="mb-3 inline-flex h-8 w-8 items-center justify-center rounded-full bg-white/10 text-sm">
-                {s.step}
-              </span>
-              <p className="text-white/80">{s.text}</p>
-            </li>
-          ))}
-        </ol>
+        <h2 className="title-h2">Comment ça marche</h2>
+        <div className="mt-6 grid gap-5 sm:grid-cols-3">
+          <div className="card"><p className="text-lg muted">1. Créez votre compte (salon ou indépendant)</p></div>
+          <div className="card"><p className="text-lg muted">2. Publiez une annonce ou recherchez une place</p></div>
+          <div className="card"><p className="text-lg muted">3. Réservez, échangez par message, signez le contrat</p></div>
+        </div>
       </section>
 
-      {/* CTA */}
-      <section className="section">
-        <div className="container-page">
-          <div className="card flex flex-col items-start justify-between gap-4 sm:flex-row sm:items-center hover:shadow-2xl transition">
-            <div>
-              <h3 className="text-xl font-semibold">Prêt à commencer ?</h3>
-              <p className="text-white/70">
-                Rejoignez des salons et indépendants partout en France.
-              </p>
+      <section className="section container-page">
+        <div className="grid gap-5 sm:grid-cols-2">
+          <div className="card">
+            <h3 className="text-xl font-semibold">Prêt à commencer ?</h3>
+            <p className="mt-2 text-inkMuted">Rejoignez des salons et indépendants partout en France.</p>
+            <div className="mt-5 grid gap-3 sm:flex">
+              <a href="/register" className="btn btn-primary glow w-full sm:w-auto">Créer un compte</a>
+              <a href="/recherche" className="btn btn-ghost w-full sm:w-auto">Voir les annonces</a>
             </div>
-            <div className="flex gap-3">
-              <NeonButton to="/register">Créer un compte</NeonButton>
-              <NeonButton to="/recherche" variant="ghost">
-                Voir les annonces
-              </NeonButton>
-            </div>
+          </div>
+          <div className="cardAlt">
+            <h3 className="text-xl font-semibold">Pourquoi Sharings</h3>
+            <ul className="mt-3 space-y-2 text-inkMuted list-disc list-inside">
+              <li>Réservation simple</li>
+              <li>Messagerie intégrée</li>
+              <li>Contrats simplifiés</li>
+            </ul>
           </div>
         </div>
       </section>
-
-      {/* FOOTER */}
-      <footer className="border-t border-white/10 py-8 text-center text-white/60">
-        <div className="container-page">
-          © {new Date().getFullYear()} Sharings — Tous droits réservés.
-        </div>
-      </footer>
-    </div>
+    </main>
   );
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,17 +4,29 @@ export default {
   theme: {
     extend: {
       colors: {
-        base: "#0f1115",
-        primary: "#2563eb",
-        accent: "#ef4444",
-        surface: "rgba(255,255,255,0.04)",
-        border: "rgba(255,255,255,0.12)",
-        ink: "#eaeef6",
+        base: "#ffffff",                // fond clair
+        ink: "#111827",                 // texte principal
+        inkMuted: "#374151",            // texte secondaire
+        line: "#E5E7EB",                // séparateurs
+        surface: "#ffffff",             // cartes blanches
+        surfaceAlt: "#F9FAFB",          // fond alterné
+        brand: {
+          primary: "#FF385C",           // Airbnb-like
+          primaryDark: "#E11D48",
+        },
       },
-      boxShadow: { soft: "0 8px 30px rgba(0,0,0,.18)" },
+      boxShadow: {
+        soft: "0 10px 30px rgba(0,0,0,.08)",
+        card: "0 8px 24px rgba(0,0,0,.06)",
+        cta: "0 12px 28px rgba(255,56,92,.25)",
+      },
+      borderRadius: {
+        xl: "14px",
+        "2xl": "18px",
+      },
       fontFamily: {
-        display: ["Playfair Display", "serif"],
-        sans: ["Inter", "ui-sans-serif", "system-ui"],
+        sans: ['Inter','system-ui','ui-sans-serif','Segoe UI','Roboto','Helvetica Neue','Arial','Noto Sans'],
+        serif: ['Playfair Display','ui-serif','Georgia','Cambria','Times New Roman','Times'],
       },
     },
   },


### PR DESCRIPTION
## Summary
- allow Unsplash images via CSP header
- add light theme tokens and components
- restyle landing page and background carousel

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run typecheck` *(fails: Cannot find module 'vite')*

------
https://chatgpt.com/codex/tasks/task_e_68ab3b5183148327b4ae9370ec4d8b17