### PR TITLE
feat: add listing search page with sample data

### DIFF
--- a/src/components/ListingCard.tsx
+++ b/src/components/ListingCard.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import type { Listing } from "../data/sampleListings";
+
+type Props = { item: Listing };
+
+export const ListingCard: React.FC<Props> = ({ item }) => {
+  return (
+    <article
+      className="group rounded-2xl border border-white/10 bg-white/5 backdrop-blur overflow-hidden shadow-lg hover:shadow-xl transition-all"
+      style={{ animation: "fade-in-up 0.5s ease both" }}
+    >
+      <div className="relative aspect-[4/3] overflow-hidden">
+        <img
+          src={item.image}
+          alt={item.title}
+          loading="lazy"
+          decoding="async"
+          className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
+          onError={(e) => {
+            (e.currentTarget as HTMLImageElement).src =
+              "https://images.unsplash.com/photo-1506806732259-39c2d0268443?auto=format&fit=crop&w=800&q=60";
+          }}
+        />
+        <div className="absolute bottom-3 left-3 rounded-xl bg-black/70 px-3 py-1 text-white text-sm">
+          {item.price}\u20ac/jour
+        </div>
+      </div>
+      <div className="p-4 sm:p-5">
+        <h3 className="text-lg sm:text-xl font-semibold text-white">{item.title}</h3>
+        <div className="mt-1 text-white/70 text-sm">\uD83D\uDCCD {item.location}</div>
+        <p className="mt-3 text-white/80 text-sm line-clamp-2">{item.description}</p>
+        <div className="mt-4 flex items-center justify-between text-sm">
+          <span className="text-amber-300">\u2B50 {item.rating.toFixed(1)} ({item.reviewsCount})</span>
+          {typeof item.distance === "number" && (
+            <span className="rounded-full bg-white/10 px-3 py-1 text-white">{item.distance.toFixed(1)} km</span>
+          )}
+        </div>
+      </div>
+    </article>
+  );
+};

--- a/src/data/sampleListings.ts
+++ b/src/data/sampleListings.ts
@@ -1,0 +1,134 @@
+export type Listing = {
+  id: number;
+  title: string;
+  location: string;
+  lat: number | null;
+  lng: number | null;
+  price: number;
+  type: "coiffure" | "esthétique" | "nail-art" | "barbier" | "extension" | "massage";
+  distance: number | null;
+  rating: number;
+  reviewsCount: number;
+  description: string;
+  features: string[];
+  address: string;
+  phone: string;
+  image: string;
+};
+
+export const sampleListings: Listing[] = [
+  {
+    id: 1,
+    title: "Salon Jean-Claude Biguine Premium",
+    location: "Paris 1er",
+    lat: 48.8566,
+    lng: 2.3522,
+    price: 75,
+    type: "coiffure",
+    distance: null,
+    rating: 4.9,
+    reviewsCount: 147,
+    description:
+      "\uD83C\uDF1F Salon de prestige au c\u0153ur de Paris. \u00C9quipements haut de gamme, ambiance luxueuse et client\u00E8le VIP.",
+    features: ["Shampoing premium", "S\u00E9choir Dyson", "Wifi fiber", "Parking priv\u00E9", "Climatisation", "Caf\u00E9 offert"],
+    address: "15 rue de Rivoli, 75001 Paris",
+    phone: "01.42.36.12.34",
+    image:
+      "https://images.unsplash.com/photo-1560066984-138dadb4c035?auto=format&fit=crop&w=800&q=60",
+  },
+  {
+    id: 2,
+    title: "Institut Clarins Prestige",
+    location: "Lyon 6\u00E8me",
+    lat: 45.764,
+    lng: 4.8357,
+    price: 65,
+    type: "esth\u00E9tique",
+    distance: null,
+    rating: 4.8,
+    reviewsCount: 98,
+    description:
+      "\u2728 Institut de beaut\u00E9 renomm\u00E9 avec cabines priv\u00E9es et gamme compl\u00E8te de produits Clarins inclus.",
+    features: ["Cabine priv\u00E9e", "Produits Clarins", "\u00C9clairage LED", "Musique zen", "Th\u00E9 premium", "Vestiaire"],
+    address: "28 cours Franklin Roosevelt, 69006 Lyon",
+    phone: "04.78.24.56.78",
+    image:
+      "https://images.unsplash.com/photo-1487412947147-5cebf100ffc2?auto=format&fit=crop&w=800&q=60",
+  },
+  {
+    id: 3,
+    title: "Nail Bar Marseille Creator",
+    location: "Marseille 2\u00E8me",
+    lat: 43.2965,
+    lng: 5.3698,
+    price: 45,
+    type: "nail-art",
+    distance: null,
+    rating: 4.7,
+    reviewsCount: 156,
+    description:
+      "\uD83D\uDC85 Le temple du nail art marseillais ! Plus de 300 vernis, techniques avant-gardistes et spot Instagram.",
+    features: ["300+ vernis", "Nail art pro", "Lampe UV/LED", "Strass & d\u00E9co", "Studio photo", "Musique"],
+    address: "45 La Canebi\u00E8re, 13002 Marseille",
+    phone: "04.91.55.78.90",
+    image:
+      "https://images.unsplash.com/photo-1522337360788-8b13dee7a37e?auto=format&fit=crop&w=800&q=60",
+  },
+  {
+    id: 4,
+    title: "Barbier Le Figaro Vintage",
+    location: "Toulouse Centre",
+    lat: 43.6047,
+    lng: 1.4442,
+    price: 55,
+    type: "barbier",
+    distance: null,
+    rating: 4.6,
+    reviewsCount: 203,
+    description:
+      "\uD83E\uDEA2 Barbier authentique avec ambiance vintage ann\u00E9es 50. Rasage traditionnel et whisky offert !",
+    features: ["Rasoir traditionnel", "Aftershave premium", "Ambiance vintage", "Whisky offert", "Journaux", "Cigare"],
+    address: "12 place du Capitole, 31000 Toulouse",
+    phone: "05.61.23.45.67",
+    image:
+      "https://images.unsplash.com/photo-1516975080664-ed2fc6a32937?auto=format&fit=crop&w=800&q=60",
+  },
+  {
+    id: 5,
+    title: "Extensions Paradise Vue Mer",
+    location: "Nice Promenade",
+    lat: 43.7102,
+    lng: 7.262,
+    price: 95,
+    type: "extension",
+    distance: null,
+    rating: 4.9,
+    reviewsCount: 78,
+    description:
+      "\uD83D\uDC87\u200D\u2640\uFE0F Sp\u00E9cialiste extensions cheveux naturels avec vue imprenable sur la M\u00E9diterran\u00E9e. Exp\u00E9rience VIP !",
+    features: ["Cheveux naturels", "Vue mer panoramique", "Parking priv\u00E9", "Champagne", "Photos pro", "Terrasse"],
+    address: "8 Promenade des Anglais, 06000 Nice",
+    phone: "04.93.87.65.43",
+    image:
+      "https://images.unsplash.com/photo-1560066984-138dadb4c035?auto=format&fit=crop&w=800&q=60",
+  },
+  {
+    id: 6,
+    title: "Spa Urbain Bordeaux Zen",
+    location: "Bordeaux Centre",
+    lat: 44.8378,
+    lng: -0.5792,
+    price: 70,
+    type: "massage",
+    distance: null,
+    rating: 4.8,
+    reviewsCount: 112,
+    description:
+      "\uD83E\uDD8C\u200D\u2640\uFE0F Massages th\u00E9rapeutiques et soins holistiques dans un cocon de bien-\u00EAtre.",
+    features: ["Table chauffante", "Huiles bio", "Diffuseur d'ar\u00F4mes", "Th\u00E9 d\u00E9tox", "Vestiaire priv\u00E9", "Douche"],
+    address: "33 cours de l'Intendance, 33000 Bordeaux",
+    phone: "05.56.78.90.12",
+    image:
+      "https://images.unsplash.com/photo-1544161515-4ab6ce6db874?auto=format&fit=crop&w=800&q=60",
+  },
+];

--- a/src/index.css
+++ b/src/index.css
@@ -22,6 +22,7 @@ body {
 .btn-primary { @apply bg-brand-primary text-white shadow-cta hover:bg-brand-primaryDark focus:ring-brand-primary; }
 .btn-ghost   { @apply border border-line text-ink hover:bg-surfaceAlt; }
 .btn-light   { @apply bg-white text-ink border border-line hover:bg-surfaceAlt shadow-soft; }
+.chip        { @apply inline-flex items-center rounded-full px-3 py-1 text-sm border border-line bg-surfaceAlt; }
 .glow { box-shadow: 0 0 30px rgba(255,56,92,.25); }
 
 /* iOS safe area + viewport réel */
@@ -41,3 +42,9 @@ body {
     clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0;
   }
 }
+
+@keyframes fade-in-up {
+  from { opacity: 0; transform: translate3d(0, 8px, 0); }
+  to   { opacity: 1; transform: translate3d(0, 0, 0); }
+}
+.fade-in-up { animation: fade-in-up .5s ease both; }

--- a/src/lib/geo.ts
+++ b/src/lib/geo.ts
@@ -1,0 +1,17 @@
+export function haversine(lat1: number, lon1: number, lat2: number, lon2: number) {
+  const R = 6371;
+  const dLat = ((lat2 - lat1) * Math.PI) / 180;
+  const dLon = ((lon2 - lon1) * Math.PI) / 180;
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos((lat1 * Math.PI) / 180) * Math.cos((lat2 * Math.PI) / 180) * Math.sin(dLon / 2) ** 2;
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  return R * c;
+}
+
+export function getCurrentPosition(): Promise<GeolocationPosition> {
+  return new Promise((resolve, reject) => {
+    if (!navigator.geolocation) return reject(new Error("Geolocation not supported"));
+    navigator.geolocation.getCurrentPosition(resolve, reject, { enableHighAccuracy: true, timeout: 8000 });
+  });
+}

--- a/src/pages/AnnoncesPage.tsx
+++ b/src/pages/AnnoncesPage.tsx
@@ -1,77 +1,106 @@
-import { useEffect, useMemo, useState } from "react"
-import { supabase } from "../lib/supa"
-import { Link } from "react-router-dom"
+import React, { useEffect, useMemo, useState } from "react";
+import { sampleListings, type Listing } from "../data/sampleListings";
+import { getCurrentPosition, haversine } from "../lib/geo";
+import { ListingCard } from "../components/ListingCard";
 
-interface Annonce {
-  id: string
-  titre: string
-  description: string
-  location?: string
-}
+type Filters = {
+  q: string;
+  type: "" | Listing["type"];
+  maxPrice: number;
+};
 
 export default function AnnoncesPage() {
-  const [annonces, setAnnonces] = useState<Annonce[]>([])
-  const [searchTerm, setSearchTerm] = useState("")
+  const [userLoc, setUserLoc] = useState<{ lat: number; lng: number } | null>(null);
+  const [filters, setFilters] = useState<Filters>({ q: "", type: "", maxPrice: 120 });
+  const [items, setItems] = useState<Listing[]>(() => sampleListings.map((l) => ({ ...l })));
+  const anyDistance = useMemo(() => items.some((i) => i.distance != null), [items]);
 
-  useEffect(() => {
-    supabase
-      .from("annonces")
-      .select("id, titre, description, location")
-      .then(({ data }) => {
-        if (data) setAnnonces(data)
-      })
-  }, [])
-
-  const filtered = useMemo(() => {
-    const term = searchTerm.toLowerCase()
-    return annonces.filter((a) =>
-      a.titre.toLowerCase().includes(term) || a.location?.toLowerCase().includes(term)
-    )
-  }, [annonces, searchTerm])
-
-  const highlight = (text: string) => {
-    if (!searchTerm) return text
-    return text.replace(new RegExp(`(${searchTerm})`, "gi"), "<mark>$1</mark>")
+  async function handleLocate() {
+    try {
+      const pos = await getCurrentPosition();
+      const loc = { lat: pos.coords.latitude, lng: pos.coords.longitude };
+      setUserLoc(loc);
+      setItems((prev) =>
+        prev.map((l) =>
+          l.lat != null && l.lng != null ? { ...l, distance: haversine(loc.lat, loc.lng, l.lat, l.lng) } : l,
+        ),
+      );
+    } catch {
+      alert("Impossible de récupérer votre position.");
+    }
   }
 
+  const filtered = useMemo(() => {
+    const q = filters.q.trim().toLowerCase();
+    return items
+      .filter((l) => (q ? l.title.toLowerCase().includes(q) || l.location.toLowerCase().includes(q) : true))
+      .filter((l) => (filters.type ? l.type === filters.type : true))
+      .filter((l) => l.price <= filters.maxPrice)
+      .sort((a, b) => {
+        if (userLoc && typeof a.distance === "number" && typeof b.distance === "number") {
+          return a.distance - b.distance;
+        }
+        return b.rating - a.rating;
+      });
+  }, [items, filters, userLoc]);
+
+  useEffect(() => {
+    document.documentElement.style.scrollBehavior = "smooth";
+  }, []);
+
   return (
-    <section className="sg-section">
-      <div className="sg-container">
-        <div className="sg-flex sg-items-center sg-justify-between">
-          <h2 className="sg-title-h2">Annonces</h2>
-          <Link to="/annonces/new" className="sg-btn-primary">
-            Nouvelle annonce
-          </Link>
-        </div>
+    <div className="container-page section">
+      <h1 className="title-h2 text-white mb-6">Trouver un espace</h1>
 
-        <div className="sg-mt-4">
+      <div className="card mb-6 grid gap-4 sm:grid-cols-4">
+        <input
+          className="col-span-2 rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-white placeholder-white/50 focus:outline-none focus:ring-2 focus:ring-white/30"
+          placeholder="Ville, arrondissement, mot-clé…"
+          value={filters.q}
+          onChange={(e) => setFilters((f) => ({ ...f, q: e.target.value }))}
+        />
+        <select
+          className="rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-white focus:outline-none focus:ring-2 focus:ring-white/30"
+          value={filters.type}
+          onChange={(e) => setFilters((f) => ({ ...f, type: e.target.value as Filters["type"] }))}
+        >
+          <option value="">Tous les services</option>
+          <option value="coiffure">Coiffure</option>
+          <option value="esthétique">Esthétique</option>
+          <option value="nail-art">Nail art</option>
+          <option value="barbier">Barbier</option>
+          <option value="extension">Extensions</option>
+          <option value="massage">Massage</option>
+        </select>
+        <div className="flex items-center gap-3">
           <input
-            type="text"
-            placeholder="Rechercher par titre ou lieu…"
-            value={searchTerm}
-            onChange={(e) => setSearchTerm(e.target.value)}
-            className="sg-w-full sg-rounded-lg sg-border sg-border-black/20 sg-px-4 sg-py-2"
+            type="range"
+            min={20}
+            max={150}
+            step={5}
+            value={filters.maxPrice}
+            onChange={(e) => setFilters((f) => ({ ...f, maxPrice: Number(e.target.value) }))}
+            className="w-full"
           />
+          <span className="chip">{filters.maxPrice}€ max</span>
         </div>
-
-        <ul className="sg-mt-6 sg-grid sg-gap-4">
-          {filtered.map((a) => (
-            <li key={a.id} className="sg-card">
-              <h3
-                className="sg-font-semibold"
-                dangerouslySetInnerHTML={{ __html: highlight(a.titre) }}
-              />
-              {a.location && (
-                <p
-                  className="sg-text-black/70 sg-mt-1"
-                  dangerouslySetInnerHTML={{ __html: highlight(a.location) }}
-                />
-              )}
-              <p className="sg-text-black/80 sg-mt-2">{a.description}</p>
-            </li>
-          ))}
-        </ul>
+        <div className="sm:col-span-4 flex flex-wrap items-center gap-3">
+          <button onClick={handleLocate} className="btn-ghost">
+            \uD83D\uDCCD {userLoc ? "Position mise à jour" : "Utiliser ma position"}
+          </button>
+          {anyDistance && <span className="text-white/60 text-sm">Tri par distance quand disponible</span>}
+        </div>
       </div>
-    </section>
-  )
+
+      {filtered.length === 0 ? (
+        <div className="text-white/70">Aucun résultat — essaye d’élargir les filtres.</div>
+      ) : (
+        <div className="grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
+          {filtered.map((l) => (
+            <ListingCard key={l.id} item={l} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- add static sample listings and geo helpers
- create reusable listing card component
- build filtered annonces page with geolocation support
- include chip utility and fade-in animation styles

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run typecheck` *(fails: cannot find type definitions / vite)*


------
https://chatgpt.com/codex/tasks/task_e_68ac7f9dac248327a75e92ab120f8b56