### PR TITLE
vérifie l'utilisateur avant la création d'annonce

### DIFF
--- a/src/pages/NewAnnoncePage.tsx
+++ b/src/pages/NewAnnoncePage.tsx
@@ -1,16 +1,28 @@
 import { useState } from "react"
 import { supabase } from "../lib/supa"
 import { useNavigate } from "react-router-dom"
+import { toast } from "react-hot-toast"
+import { useAuth } from "../contexts/AuthContext"
 
 export default function NewAnnoncePage() {
   const [titre, setTitre] = useState("")
   const [description, setDescription] = useState("")
   const navigate = useNavigate()
+  const { user } = useAuth()
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
+    if (!user) {
+      toast.error("Vous devez être connecté pour publier")
+      return
+    }
     const { error } = await supabase.from("annonces").insert({ titre, description })
-    if (!error) navigate("/annonces")
+    if (error) {
+      toast.error(error.message)
+    } else {
+      toast.success("Annonce publiée")
+      navigate("/annonces")
+    }
   }
 
   return (

--- a/tests/ui/new-annonce.test.tsx
+++ b/tests/ui/new-annonce.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import NewAnnoncePage from "../../src/pages/NewAnnoncePage";
+
+// mocks
+const insertMock = vi.fn();
+vi.mock("../../src/lib/supa", () => ({
+  supabase: { from: vi.fn(() => ({ insert: insertMock })) }
+}));
+const useAuthMock = vi.fn();
+vi.mock("../../src/contexts/AuthContext", () => ({ useAuth: useAuthMock }));
+const toastSuccessMock = vi.fn();
+const toastErrorMock = vi.fn();
+vi.mock("react-hot-toast", () => ({ toast: { success: toastSuccessMock, error: toastErrorMock } }));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("NewAnnoncePage", () => {
+  it("publishes annonce when user authenticated", async () => {
+    useAuthMock.mockReturnValue({ user: { id: "1" } });
+    insertMock.mockResolvedValue({ error: null });
+    render(
+      <MemoryRouter>
+        <NewAnnoncePage />
+      </MemoryRouter>
+    );
+    fireEvent.change(screen.getByPlaceholderText("Titre"), { target: { value: "foo" } });
+    fireEvent.change(screen.getByPlaceholderText("Description"), { target: { value: "bar" } });
+    fireEvent.click(screen.getByRole("button", { name: /Publier/i }));
+    await waitFor(() => expect(insertMock).toHaveBeenCalled());
+    expect(toastSuccessMock).toHaveBeenCalledWith("Annonce publiée");
+  });
+
+  it("shows error when user not authenticated", async () => {
+    useAuthMock.mockReturnValue({ user: null });
+    render(
+      <MemoryRouter>
+        <NewAnnoncePage />
+      </MemoryRouter>
+    );
+    fireEvent.change(screen.getByPlaceholderText("Titre"), { target: { value: "foo" } });
+    fireEvent.change(screen.getByPlaceholderText("Description"), { target: { value: "bar" } });
+    fireEvent.click(screen.getByRole("button", { name: /Publier/i }));
+    await waitFor(() => expect(toastErrorMock).toHaveBeenCalled());
+    expect(insertMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- assure qu'un utilisateur est connecté avant de créer une annonce et affiche des toasts de succès ou d'échec
- ajoute un test UI couvrant la création d'annonce

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@playwright%2ftest)*
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68adfd6c53948327907403cad3f08121