### PR TITLE
refactor: use controlled carousel and toast

### DIFF
--- a/src/components/__tests__/BackgroundCarousel.test.tsx
+++ b/src/components/__tests__/BackgroundCarousel.test.tsx
@@ -3,12 +3,7 @@ import { describe, it, expect, vi } from "vitest";
 import { render } from "@testing-library/react";
 import BackgroundCarousel from "../BackgroundCarousel";
 
-import { describe, it, expect, vi } from "vitest"
-import { render } from "@testing-library/react"
-import BackgroundCarousel from "../BackgroundCarousel"
- main
-
-vi.useFakeTimers()
+vi.useFakeTimers();
 
 describe("BackgroundCarousel", () => {
   it("renders first image and auto-rotates", () => {
@@ -19,16 +14,14 @@ describe("BackgroundCarousel", () => {
     vi.advanceTimersByTime(1500);
     expect(container.querySelector("img")?.getAttribute("src")).toBe("/hero/2.jpg");
   });
-});
 
   it("rotates images", () => {
     const { container } = render(
-      <BackgroundCarousel slides={[{ src: "/a.jpg" }, { src: "/b.jpg" }]} intervalMs={1000} />
-    )
-    const imgs = container.querySelectorAll("img")
-    expect(imgs[0].className).toContain("opacity-100")
-    vi.advanceTimersByTime(1500)
-    expect(imgs[1].className).toContain("opacity-100")
-  })
-})
- main
+      <BackgroundCarousel images={[{ src: "/a.jpg" }, { src: "/b.jpg" }]} intervalMs={1000} />
+    );
+    const imgs = container.querySelectorAll("img");
+    expect(imgs[0].className).toContain("opacity-100");
+    vi.advanceTimersByTime(1500);
+    expect(imgs[1].className).toContain("opacity-100");
+  });
+});

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -1,4 +1,7 @@
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
+import { Toaster, toast } from "react-hot-toast";
+import BackgroundCarousel from "../components/BackgroundCarousel";
+import { HERO_BG_IMAGES } from "../data/heroImages";
 
 /** ------------------------------------------------------------------
  *  PAGE D’ACCUEIL SHARINGS – Version “tout-en-un”
@@ -94,6 +97,8 @@ const sampleListings: Listing[] = [
   }
 ];
 
+const heroImages = HERO_BG_IMAGES.map((src) => ({ src }));
+
 export default function LandingPage() {
   const [currentUser, setCurrentUser] = useState<User | null>(null);
   const [listings, setListings] = useState<Listing[]>(() => sampleListings.map(l => ({ ...l })));
@@ -104,18 +109,7 @@ export default function LandingPage() {
   const [showAuth, setShowAuth] = useState(false);
   const [showListingModal, setShowListingModal] = useState(false);
 
-  // Carrousel
-  const slideIndex = useRef(0);
-  useEffect(() => {
-    const slides = document.querySelectorAll<HTMLDivElement>(".carousel-slide");
-    if (!slides.length) return;
-    const timer = setInterval(() => {
-      slides[slideIndex.current % slides.length]?.classList.remove("active");
-      slideIndex.current = (slideIndex.current + 1) % slides.length;
-      slides[slideIndex.current]?.classList.add("active");
-    }, 5000);
-    return () => clearInterval(timer);
-  }, []);
+  // Carrousel géré par React (via BackgroundCarousel)
 
   // Animations “fadeInUp” sur les cards
   useEffect(() => {
@@ -218,18 +212,20 @@ export default function LandingPage() {
     (e.target as HTMLFormElement).reset();
   };
 
-  // Notifications (petit toaster)
-  const notify = (msg: string, type: "success"|"error"|"warning"|"info" = "info") => {
-    const el = document.createElement("div");
-    el.textContent = msg;
-    el.className = `toast ${type}`;
-    document.body.appendChild(el);
-    setTimeout(() => el.classList.add("hide"), 2600);
-    setTimeout(() => el.remove(), 3000);
+  // Notifications via react-hot-toast
+  const notify = (
+    msg: string,
+    type: "success" | "error" | "warning" | "info" = "info"
+  ) => {
+    if (type === "success") toast.success(msg);
+    else if (type === "error") toast.error(msg);
+    else if (type === "warning") toast(msg, { icon: "⚠️" });
+    else toast(msg);
   };
 
   return (
     <>
+      <Toaster position="top-right" />
       {/* NAV */}
       <nav className="navbar">
         <div className="nav-container">
@@ -264,12 +260,7 @@ export default function LandingPage() {
 
       {/* HERO */}
       <section className="hero">
-        <div className="hero-carousel">
-          <div className="carousel-slide active" style={{ backgroundImage: `url(https://images.unsplash.com/photo-1560066984-138dadb4c035?auto=format&fit=crop&w=1920&q=80)` }} />
-          <div className="carousel-slide" style={{ backgroundImage: `url(https://images.unsplash.com/photo-1487412947147-5cebf100ffc2?auto=format&fit=crop&w=1920&q=80)` }} />
-          <div className="carousel-slide" style={{ backgroundImage: `url(https://images.unsplash.com/photo-1522337360788-8b13dee7a37e?auto=format&fit=crop&w=1920&q=80)` }} />
-          <div className="carousel-slide" style={{ backgroundImage: `url(https://images.unsplash.com/photo-1516975080664-ed2fc6a32937?auto=format&fit=crop&w=1920&q=80)` }} />
-        </div>
+        <BackgroundCarousel images={heroImages} intervalMs={5000} className="hero-carousel" />
         <div className="hero-content">
           <h1 className="hero-title">Révolutionnez votre activité beauté</h1>
           <p className="hero-subtitle">
@@ -515,10 +506,6 @@ export default function LandingPage() {
 
         /* Hero */
         .hero{height:100vh;min-height:680px;position:relative;display:flex;align-items:center;justify-content:center;overflow:hidden}
-        .hero-carousel{position:absolute;inset:0}
-        .carousel-slide{position:absolute;inset:0;background-size:cover;background-position:center;opacity:0;transition:opacity 2s}
-        .carousel-slide.active{opacity:1}
-        .carousel-slide::after{content:"";position:absolute;inset:0;background:linear-gradient(135deg,rgba(0,0,0,.4),rgba(0,0,0,.65))}
         .hero-content{position:relative;z-index:2;text-align:center;color:#fff;max-width:900px;padding:0 24px}
         .hero-title{font-size:clamp(2.5rem,8vw,5.2rem);font-weight:900;letter-spacing:-.02em;margin:0 0 12px;text-shadow:0 4px 20px rgba(0,0,0,.45)}
         .hero-subtitle{font-size:clamp(1.1rem,3vw,1.6rem);opacity:.95;margin:0 0 32px}
@@ -570,11 +557,6 @@ export default function LandingPage() {
         .btn-full{width:100%;padding:14px 18px;border-radius:12px;margin-top:4px}
         .switch{margin:8px 0 0;color:var(--muted)}
         .switch a{text-decoration:underline}
-
-        /* Toast */
-        .toast{position:fixed;right:20px;top:20px;background:#667eea;color:#fff;padding:12px 16px;border-radius:10px;box-shadow:var(--shadow);z-index:2000;transition:opacity .3s, transform .3s}
-        .toast.success{background:#10b981}.toast.error{background:#ef4444}.toast.warning{background:#f59e0b}
-        .toast.hide{opacity:0;transform:translateY(-10px)}
 
         /* Responsive */
         @media (max-width: 960px){


### PR DESCRIPTION
## Summary
- replace manual hero carousel with controlled `BackgroundCarousel`
- use `react-hot-toast` for notifications and add `<Toaster/>`
- clean up `BackgroundCarousel` test file

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden accessing @playwright/test)*

------
https://chatgpt.com/codex/tasks/task_e_68adfd6feb68832799c2a26cfd7b58fc