### PR TITLE
Guard BackgroundCarousel against empty image arrays

### DIFF
--- a/src/components/BackgroundCarousel.tsx
+++ b/src/components/BackgroundCarousel.tsx
@@ -25,6 +25,7 @@ export default function BackgroundCarousel({
   const paused = useRef(false);
 
   useEffect(() => {
+    if (images.length === 0) return;
     start();
     return stop;
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/components/__tests__/BackgroundCarousel.test.tsx
+++ b/src/components/__tests__/BackgroundCarousel.test.tsx
@@ -3,12 +3,7 @@ import { describe, it, expect, vi } from "vitest";
 import { render } from "@testing-library/react";
 import BackgroundCarousel from "../BackgroundCarousel";
 
-import { describe, it, expect, vi } from "vitest"
-import { render } from "@testing-library/react"
-import BackgroundCarousel from "../BackgroundCarousel"
- main
-
-vi.useFakeTimers()
+vi.useFakeTimers();
 
 describe("BackgroundCarousel", () => {
   it("renders first image and auto-rotates", () => {
@@ -19,16 +14,24 @@ describe("BackgroundCarousel", () => {
     vi.advanceTimersByTime(1500);
     expect(container.querySelector("img")?.getAttribute("src")).toBe("/hero/2.jpg");
   });
-});
 
   it("rotates images", () => {
     const { container } = render(
-      <BackgroundCarousel slides={[{ src: "/a.jpg" }, { src: "/b.jpg" }]} intervalMs={1000} />
-    )
-    const imgs = container.querySelectorAll("img")
-    expect(imgs[0].className).toContain("opacity-100")
-    vi.advanceTimersByTime(1500)
-    expect(imgs[1].className).toContain("opacity-100")
-  })
-})
- main
+      <BackgroundCarousel images={[{ src: "/a.jpg" }, { src: "/b.jpg" }]} intervalMs={1000} />
+    );
+    const imgs = container.querySelectorAll("img");
+    expect(imgs[0].className).toContain("opacity-100");
+    vi.advanceTimersByTime(1500);
+    expect(imgs[1].className).toContain("opacity-100");
+  });
+
+  it("does nothing when images array is empty", () => {
+    const intervalSpy = vi.spyOn(window, "setInterval");
+    const { container } = render(
+      <BackgroundCarousel images={[]} intervalMs={1000} />
+    );
+    expect(container.querySelectorAll("img")).toHaveLength(0);
+    expect(intervalSpy).not.toHaveBeenCalled();
+    intervalSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- Skip starting the carousel timer when no images are provided
- Add tests including a case for an empty image array

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68adfd6e57cc83278cfb7617b75764f8