### PR TITLE
feat: wrap payments in transactions

### DIFF
--- a/server/routes/payments.js
+++ b/server/routes/payments.js
@@ -5,14 +5,21 @@ export default function paymentRoutes(prisma) {
   const router = Router();
 
   router.post('/access', authMiddleware, async (req, res) => {
-    await prisma.payment.create({
-      data: { userId: req.user.userId, amount: 4.99, type: 'access' }
-    });
-    await prisma.user.update({
-      where: { id: req.user.userId },
-      data: { paidAccess: true }
-    });
-    res.json({ success: true });
+    try {
+      await prisma.$transaction([
+        prisma.payment.create({
+          data: { userId: req.user.userId, amount: 4.99, type: 'access' }
+        }),
+        prisma.user.update({
+          where: { id: req.user.userId },
+          data: { paidAccess: true }
+        })
+      ]);
+      res.json({ success: true });
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ error: 'PAYMENT_ERROR' });
+    }
   });
 
   router.post('/listing/:id', authMiddleware, async (req, res) => {
@@ -20,30 +27,44 @@ export default function paymentRoutes(prisma) {
     const activeUntil = new Date();
     activeUntil.setMonth(activeUntil.getMonth() + 1);
 
-    await prisma.payment.create({
-      data: { userId: req.user.userId, amount: 9.99, type: 'listing' }
-    });
-    await prisma.listing.update({
-      where: { id: listingId },
-      data: { activeUntil }
-    });
-    res.json({ success: true });
+    try {
+      await prisma.$transaction([
+        prisma.payment.create({
+          data: { userId: req.user.userId, amount: 9.99, type: 'listing' }
+        }),
+        prisma.listing.update({
+          where: { id: listingId },
+          data: { activeUntil }
+        })
+      ]);
+      res.json({ success: true });
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ error: 'PAYMENT_ERROR' });
+    }
   });
 
   router.post('/search', authMiddleware, async (req, res) => {
     const { description, city } = req.body;
 
-    await prisma.payment.create({
-      data: { userId: req.user.userId, amount: 9.99, type: 'search' }
-    });
-    const request = await prisma.searchRequest.create({
-      data: {
-        clientId: req.user.userId,
-        description,
-        city
-      }
-    });
-    res.json(request);
+    try {
+      const [, request] = await prisma.$transaction([
+        prisma.payment.create({
+          data: { userId: req.user.userId, amount: 9.99, type: 'search' }
+        }),
+        prisma.searchRequest.create({
+          data: {
+            clientId: req.user.userId,
+            description,
+            city
+          }
+        })
+      ]);
+      res.json(request);
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ error: 'PAYMENT_ERROR' });
+    }
   });
 
   return router;


### PR DESCRIPTION
## Summary
- use prisma transactions to group payment creation with updates
- catch errors and surface payment failure status

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run test:api`


------
https://chatgpt.com/codex/tasks/task_e_68adfd719d2c83279ded8a31cf8c0753