### PR TITLE
Filter listings by city via salon relation

### DIFF
--- a/server/routes/listings.js
+++ b/server/routes/listings.js
@@ -23,7 +23,7 @@ export default function listingRoutes(prisma) {
     const listings = await prisma.listing.findMany({
       where: {
         status: 'active',
-        salon: city ? { city } : undefined
+        salon: { city }
       },
       include: { salon: true }
     });

--- a/server/tests/listings.test.js
+++ b/server/tests/listings.test.js
@@ -1,0 +1,35 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import express from 'express';
+import listingRoutes from '../routes/listings.js';
+
+test('GET /listings?city=Paris filters by city', async () => {
+  let receivedArgs;
+  const prisma = {
+    listing: {
+      findMany: async (args) => {
+        receivedArgs = args;
+        return [{ id: 1, salon: { city: 'Paris' } }];
+      }
+    }
+  };
+
+  const app = express();
+  app.use('/listings', listingRoutes(prisma));
+  const server = app.listen();
+  await new Promise((resolve) => server.once('listening', resolve));
+  const { port } = server.address();
+
+  const res = await fetch(`http://localhost:${port}/listings?city=Paris`);
+  const body = await res.json();
+
+  assert.equal(res.status, 200);
+  assert.deepEqual(receivedArgs.where, {
+    status: 'active',
+    salon: { city: 'Paris' }
+  });
+  assert.deepEqual(body, [{ id: 1, salon: { city: 'Paris' } }]);
+
+  server.close();
+});
+


### PR DESCRIPTION
## Summary
- refine listing query to filter by salon city
- add API test verifying `/listings?city=Paris` uses city filter

## Testing
- `node --test server/tests/listings.test.js` *(fails: Cannot find package 'express')*


------
https://chatgpt.com/codex/tasks/task_e_68adfd72bdcc8327be821df4a1a8b60d