### PR TITLE
feat: add request validation middleware and tests

### DIFF
--- a/server/middleware/validate.js
+++ b/server/middleware/validate.js
@@ -1,0 +1,27 @@
+export function validate(schema, property = 'body') {
+  return (req, res, next) => {
+    const data = req[property] || {};
+    for (const [key, rule] of Object.entries(schema)) {
+      const def = typeof rule === 'string' ? { type: rule } : rule;
+      const { type, optional } = def;
+      let value = data[key];
+      if (value === undefined) {
+        if (!optional) {
+          return res.status(400).json({ error: `${key} is required` });
+        }
+      } else {
+        if (type === 'number') {
+          const num = Number(value);
+          if (Number.isNaN(num)) {
+            return res.status(400).json({ error: `${key} must be a number` });
+          }
+          data[key] = num;
+        } else if (typeof value !== type) {
+          return res.status(400).json({ error: `${key} must be a ${type}` });
+        }
+      }
+    }
+    req[property] = data;
+    next();
+  };
+}

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -1,11 +1,17 @@
 import { Router } from 'express';
 import bcrypt from 'bcrypt';
 import jwt from 'jsonwebtoken';
+import { validate } from '../middleware/validate.js';
 
 export default function authRoutes(prisma) {
   const router = Router();
 
-  router.post('/register', async (req, res) => {
+  const registerSchema = {
+    email: 'string',
+    password: 'string',
+    role: 'string'
+  };
+  router.post('/register', validate(registerSchema), async (req, res) => {
     try {
       const { email, password, role } = req.body;
       const hash = await bcrypt.hash(password, 10);
@@ -14,22 +20,30 @@ export default function authRoutes(prisma) {
       });
       res.json({ id: user.id, email: user.email, role: user.role });
     } catch (err) {
-      res.status(400).json({ error: 'Registration failed' });
+      res.status(400).json({ error: err.message });
     }
   });
 
-  router.post('/login', async (req, res) => {
-    const { email, password } = req.body;
-    const user = await prisma.user.findUnique({ where: { email } });
-    if (!user) return res.status(401).json({ message: 'Invalid credentials' });
-    const valid = await bcrypt.compare(password, user.password);
-    if (!valid) return res.status(401).json({ message: 'Invalid credentials' });
-    const token = jwt.sign(
-      { userId: user.id, role: user.role },
-      process.env.JWT_SECRET || 'SECRET',
-      { expiresIn: '30d' }
-    );
-    res.json({ token });
+  const loginSchema = {
+    email: 'string',
+    password: 'string'
+  };
+  router.post('/login', validate(loginSchema), async (req, res) => {
+    try {
+      const { email, password } = req.body;
+      const user = await prisma.user.findUnique({ where: { email } });
+      if (!user) return res.status(401).json({ error: 'Invalid credentials' });
+      const valid = await bcrypt.compare(password, user.password);
+      if (!valid) return res.status(401).json({ error: 'Invalid credentials' });
+      const token = jwt.sign(
+        { userId: user.id, role: user.role },
+        process.env.JWT_SECRET || 'SECRET',
+        { expiresIn: '30d' }
+      );
+      res.json({ token });
+    } catch (err) {
+      res.status(400).json({ error: err.message });
+    }
   });
 
   return router;

--- a/server/routes/listings.js
+++ b/server/routes/listings.js
@@ -1,10 +1,18 @@
 import { Router } from 'express';
 import { authMiddleware } from '../middleware/auth.js';
+import { validate } from '../middleware/validate.js';
 
 export default function listingRoutes(prisma) {
   const router = Router();
 
-  router.post('/', authMiddleware, async (req, res) => {
+  const createSchema = {
+    salonId: 'number',
+    title: 'string',
+    description: 'string',
+    priceDay: 'number',
+    priceWeek: 'number'
+  };
+  router.post('/', authMiddleware, validate(createSchema), async (req, res) => {
     const { salonId, title, description, priceDay, priceWeek } = req.body;
     const activeUntil = new Date();
     activeUntil.setMonth(activeUntil.getMonth() + 1);
@@ -13,21 +21,26 @@ export default function listingRoutes(prisma) {
         data: { salonId, title, description, priceDay, priceWeek, activeUntil }
       });
       res.json(listing);
-    } catch {
-      res.status(400).json({ error: 'Unable to create listing' });
+    } catch (err) {
+      res.status(400).json({ error: err.message });
     }
   });
 
-  router.get('/', async (req, res) => {
-    const { city } = req.query;
-    const listings = await prisma.listing.findMany({
-      where: {
-        status: 'active',
-        salon: city ? { city } : undefined
-      },
-      include: { salon: true }
-    });
-    res.json(listings);
+  const querySchema = { city: { type: 'string', optional: true } };
+  router.get('/', validate(querySchema, 'query'), async (req, res) => {
+    try {
+      const { city } = req.query;
+      const listings = await prisma.listing.findMany({
+        where: {
+          status: 'active',
+          salon: city ? { city } : undefined
+        },
+        include: { salon: true }
+      });
+      res.json(listings);
+    } catch (err) {
+      res.status(400).json({ error: err.message });
+    }
   });
 
   return router;

--- a/server/tests/routes.test.js
+++ b/server/tests/routes.test.js
@@ -1,0 +1,135 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import express from 'express';
+import jwt from 'jsonwebtoken';
+import authRoutes from '../routes/auth.js';
+import listingRoutes from '../routes/listings.js';
+import paymentRoutes from '../routes/payments.js';
+
+function mockRes() {
+  return {
+    statusCode: 200,
+    body: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(obj) {
+      this.body = obj;
+      return this;
+    }
+  };
+}
+
+// Auth route tests
+const prismaAuth = {
+  user: {
+    create: async () => {
+      throw new Error('fail');
+    },
+    findUnique: async () => null
+  }
+};
+const authRouter = authRoutes(prismaAuth);
+const authLayer = authRouter.stack.find(l => l.route && l.route.path === '/register').route.stack;
+const authValidate = authLayer[0].handle;
+const authHandler = authLayer[1].handle;
+
+test('register validation requires password', () => {
+  const req = { body: { email: 'a@b.com', role: 'user' } };
+  const res = mockRes();
+  authValidate(req, res, () => {});
+  assert.equal(res.statusCode, 400);
+  assert.match(res.body.error, /password/);
+});
+
+test('register handler returns explicit prisma error', async () => {
+  const req = { body: { email: 'a@b.com', password: 'secret', role: 'user' } };
+  const res = mockRes();
+  authValidate(req, res, async () => {
+    await authHandler(req, res);
+  });
+  assert.equal(res.statusCode, 400);
+  assert.equal(res.body.error, 'fail');
+});
+
+// Listings route tests
+const prismaListings = {
+  listing: {
+    findMany: async () => {
+      throw new Error('listings fail');
+    }
+  }
+};
+const listingRouter = listingRoutes(prismaListings);
+const listLayer = listingRouter.stack.find(l => l.route && l.route.path === '/').route.stack;
+const listValidate = listLayer[0].handle;
+const listHandler = listLayer[1].handle;
+
+test('listings validation rejects wrong type', () => {
+  const req = { query: { city: 123 } };
+  const res = mockRes();
+  listValidate(req, res, () => {});
+  assert.equal(res.statusCode, 400);
+  assert.match(res.body.error, /city/);
+});
+
+test('listings handler returns prisma error', async () => {
+  const req = { query: { city: 'Paris' } };
+  const res = mockRes();
+  await new Promise(resolve => {
+    listValidate(req, res, async () => {
+      await listHandler(req, res);
+      resolve();
+    });
+  });
+  assert.equal(res.statusCode, 400);
+  assert.equal(res.body.error, 'listings fail');
+});
+
+// Payments route tests
+const prismaPayments = {
+  payment: {
+    create: async () => {
+      throw new Error('payment fail');
+    }
+  },
+  user: {
+    update: async () => {}
+  },
+  listing: {
+    update: async () => {}
+  },
+  searchRequest: {
+    create: async () => ({ id: 1 })
+  }
+};
+const paymentRouter = paymentRoutes(prismaPayments);
+const searchLayer = paymentRouter.stack.find(l => l.route && l.route.path === '/search').route.stack;
+const searchAuth = searchLayer[0].handle;
+const searchValidate = searchLayer[1].handle;
+const searchHandler = searchLayer[2].handle;
+
+test('payments validation requires city', async () => {
+  const token = jwt.sign({ userId: 1 }, 'SECRET');
+  const req = { headers: { authorization: `Bearer ${token}` }, body: { description: 'desc' } };
+  const res = mockRes();
+  await new Promise(resolve => searchAuth(req, res, resolve));
+  searchValidate(req, res, () => {});
+  assert.equal(res.statusCode, 400);
+  assert.match(res.body.error, /city/);
+});
+
+test('payments handler returns prisma error', async () => {
+  const token = jwt.sign({ userId: 1 }, 'SECRET');
+  const req = { headers: { authorization: `Bearer ${token}` }, body: { description: 'desc', city: 'Paris' }, user: { userId: 1 } };
+  const res = mockRes();
+  await new Promise(resolve => searchAuth(req, res, () => {
+    searchValidate(req, res, async () => {
+      await searchHandler(req, res);
+      resolve();
+    });
+  }));
+  assert.equal(res.statusCode, 400);
+  assert.equal(res.body.error, 'payment fail');
+});


### PR DESCRIPTION
## Summary
- add custom request validation middleware
- validate inputs and wrap Prisma operations with error handling
- include unit tests for validation and error scenarios

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run test:api` *(fails: test imports missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68adfd737bb083278f6e8f1c262de36b