### PR TITLE
feat: redirect to dashboard after login

### DIFF
--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { Toaster, toast } from "react-hot-toast";
 import BackgroundCarousel from "../components/BackgroundCarousel";
 import { HERO_BG_IMAGES } from "../data/heroImages";
@@ -108,6 +109,7 @@ export default function LandingPage() {
   const [authMode, setAuthMode] = useState<"login"|"register">("login");
   const [showAuth, setShowAuth] = useState(false);
   const [showListingModal, setShowListingModal] = useState(false);
+  const navigate = useNavigate();
 
   // Carrousel géré par React (via BackgroundCarousel)
 
@@ -172,6 +174,7 @@ export default function LandingPage() {
     setCurrentUser({ id: 1, email, name, type });
     setShowAuth(false);
     notify("🎉 Connexion réussie !", "success");
+    navigate("/dashboard");
   };
 
   const handleRegister = (e: React.FormEvent) => {


### PR DESCRIPTION
## Summary
- import and use react-router navigation on landing page
- redirect to dashboard once login succeeds

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@playwright%2ftest)*

------
https://chatgpt.com/codex/tasks/task_e_68ae140301c88327a81930840c936de5