### PR TITLE
fix: clean up login route

### DIFF
--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -23,23 +23,6 @@ export default function authRoutes(prisma) {
       res.status(400).json({ error: err.message });
     }
   });
-
-  router.post('/login', async (req, res) => {
-    const { email, password } = req.body;
-    if (!process.env.JWT_SECRET) {
-      return res.status(500).json({ message: 'JWT_SECRET not configured' });
-    }
-    const user = await prisma.user.findUnique({ where: { email } });
-    if (!user) return res.status(401).json({ message: 'Invalid credentials' });
-    const valid = await bcrypt.compare(password, user.password);
-    if (!valid) return res.status(401).json({ message: 'Invalid credentials' });
-    const token = jwt.sign(
-      { userId: user.id, role: user.role },
-      process.env.JWT_SECRET,
-      { expiresIn: '30d' }
-    );
-    res.json({ token });
-
   const loginSchema = {
     email: 'string',
     password: 'string'
@@ -60,7 +43,6 @@ export default function authRoutes(prisma) {
     } catch (err) {
       res.status(400).json({ error: err.message });
     }
- main
   });
 
   return router;


### PR DESCRIPTION
## Summary
- remove partial `/login` implementation and keep validated version
- clean up leftover merge text

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run test:api`


------
https://chatgpt.com/codex/tasks/task_e_68aeb7186e6883279d0622ac81a57b4b