### PR TITLE
Support city name search fallback and handle missing cities

### DIFF
--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -3,6 +3,7 @@ import { supabase } from "./supa"
 export type SearchParams = {
   q?: string
   cityId?: string
+  cityName?: string
   services?: string[]
   priceMax?: number
   sort?: "rating" | "price"
@@ -12,13 +13,25 @@ export type SearchParams = {
 export async function searchBusinesses(p: SearchParams) {
   const page = p.page ?? 1
   const size = p.pageSize ?? 20
+  let cityId = p.cityId
+  if (!cityId && p.cityName) {
+    const { data: cityData, error: cityError } = await supabase
+      .from("cities")
+      .select("id")
+      .ilike("name", p.cityName)
+      .limit(1)
+      .maybeSingle()
+    if (cityError) throw cityError
+    if (!cityData) throw new Error("Ville introuvable")
+    cityId = cityData.id
+  }
   let q = supabase
     .from("businesses")
     .select("id,kind,name,address,price_min,price_max,rating,tags,images,city:cities(name)", { count: "exact" })
     .limit(size)
     .range((page - 1) * size, page * size - 1)
     .order(p.sort === "price" ? "price_min" : "rating", { ascending: p.sort === "price" })
-  if (p.cityId) q = q.eq("city_id", p.cityId)
+  if (cityId) q = q.eq("city_id", cityId)
   if (p.q) q = q.ilike("name", `%${p.q}%`)
   if (p.services?.length) q = q.contains("tags", p.services)
   if (p.priceMax) q = q.lte("price_max", p.priceMax)

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -9,11 +9,19 @@ export default function SearchPage() {
   const [services, setServices] = useState<string[]>([]); const [priceMax, setPriceMax] = useState<number>(120);
   const [page, setPage] = useState(1);
   const [res, setRes] = useState<any>({ data: [], count: 0 });
+  const [error, setError] = useState<string|null>(null);
 
   useEffect(() => { (async () => {
-    const r = await searchBusinesses({ q, cityId: city?.id, services, priceMax, page, sort: "rating" });
-    setRes(r);
-  })(); }, [q, city?.id, services, priceMax, page]);
+    try {
+      const cityName = city ? undefined : cityInput.trim() || undefined;
+      const r = await searchBusinesses({ q, cityId: city?.id, cityName, services, priceMax, page, sort: "rating" });
+      setRes(r);
+      setError(null);
+    } catch (e: any) {
+      setError(e.message);
+      setRes({ data: [], count: 0 });
+    }
+  })(); }, [q, city?.id, cityInput, services, priceMax, page]);
 
   useEffect(() => { (async () => {
     if (cityInput.trim().length < 2) { setCities([]); return; }
@@ -31,6 +39,7 @@ export default function SearchPage() {
           <div className="md:col-span-2">
             <label className="text-sm text-white/70">Ville</label>
             <input value={cityInput} onChange={(e)=>setCityInput(e.target.value)} placeholder="Paris, Lyon…" className="w-full mt-1 rounded-xl bg-white/5 border border-white/10 px-3 py-2"/>
+            {error && <div className="mt-1 text-sm text-red-400">{error}</div>}
             {cities.length>0 && (
               <div className="mt-2 bg-base border border-white/10 rounded-xl p-2 max-h-56 overflow-auto">
                 {cities.map(c => (


### PR DESCRIPTION
## Summary
- Allow business search to fall back to city name input when no city selected
- Translate city name to ID on backend and raise error if city not found
- Display user-facing error message when no matching city exists

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden - @playwright/test)*

------
https://chatgpt.com/codex/tasks/task_e_68aeb7163fbc8327aec0842943223333