### PR TITLE
Redirect to dashboard after login

### DIFF
--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -18,7 +18,7 @@ export default function LoginPage() {
       toast.error(error.message)
     } else {
       toast.success("Connexion réussie")
-      navigate("/")
+      navigate("/dashboard")
     }
   }
 

--- a/tests/ui/login.test.tsx
+++ b/tests/ui/login.test.tsx
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+import LoginPage from "../../src/pages/LoginPage";
+import DashboardPage from "../../src/pages/DashboardPage";
+
+vi.mock("../../src/lib/supa", () => ({
+  supabase: {
+    auth: {
+      signInWithPassword: vi.fn().mockResolvedValue({ error: null }),
+    },
+  },
+}));
+
+vi.mock("../../src/contexts/AuthContext", () => ({
+  useAuth: () => ({ user: { email: "test@example.com" }, loading: false }),
+}));
+
+describe("LoginPage", () => {
+  it("redirects to dashboard after successful login", async () => {
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter initialEntries={["/login"]}>
+        <Routes>
+          <Route path="/login" element={<LoginPage />} />
+          <Route path="/dashboard" element={<DashboardPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await user.type(screen.getByPlaceholderText(/Email/i), "test@example.com");
+    await user.type(screen.getByPlaceholderText(/Mot de passe/i), "password");
+    await user.click(screen.getByRole("button", { name: /Se connecter/i }));
+
+    expect(await screen.findByText(/Tableau de bord/i)).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- redirect users to dashboard after successful login
- add UI test to confirm dashboard navigation after login

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@playwright%2ftest)*
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aeb71523588327a4f3334cf00df2c5