### PR TITLE
feat: add city and business tables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+*.tsbuildinfo
 
 # Editor directories and files
 .vscode/*

--- a/supabase.sql
+++ b/supabase.sql
@@ -36,3 +36,34 @@ create policy "Annonces publiques" on annonces for select using (true);
 create policy "Gestion proprieataire" on annonces for insert using (auth.uid() = user_id) with check (auth.uid() = user_id);
 create policy "Update propre" on annonces for update using (auth.uid() = user_id) with check (auth.uid() = user_id);
 create policy "Delete propre" on annonces for delete using (auth.uid() = user_id);
+
+-- Table des villes
+create table if not exists cities (
+  id uuid primary key default gen_random_uuid(),
+  insee_code text unique not null,
+  name text not null,
+  lat numeric,
+  lon numeric,
+  population integer
+);
+
+alter table cities enable row level security;
+create policy "Villes publiques" on cities for select using (true);
+
+-- Table des entreprises
+create table if not exists businesses (
+  id uuid primary key default gen_random_uuid(),
+  kind text check (kind in ('salon','institut')),
+  name text not null,
+  city_id uuid references cities(id) on delete set null,
+  address text,
+  price_min integer,
+  price_max integer,
+  rating numeric,
+  tags text[] default '{}',
+  images jsonb default '[]'::jsonb,
+  created_at timestamptz default now()
+);
+
+alter table businesses enable row level security;
+create policy "Entreprises publiques" on businesses for select using (true);


### PR DESCRIPTION
## Summary
- define `cities` table for location lookup
- add `businesses` table linked to cities
- ignore TypeScript build info files

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run test:api`
- `npm run typecheck` *(fails: Cannot find module 'vite' or its types)*

------
https://chatgpt.com/codex/tasks/task_e_68aeb3e700a883278085eaf1b5a0b73b